### PR TITLE
Add a FileClassType enum to ProcessedFileInfo

### DIFF
--- a/RoboSharp/ProcessedFileInfo.cs
+++ b/RoboSharp/ProcessedFileInfo.cs
@@ -1,8 +1,16 @@
 ﻿namespace RoboSharp
 {
+    public enum FileClassType
+    {
+        NewDir,
+        File,
+        SystemMessage
+    }
+
     public class ProcessedFileInfo
     {
         public string FileClass { get; set; }
+        public FileClassType FileClassType { get; set; }
         public long Size { get; set; }
         public string Name { get; set; }
     }

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -92,6 +92,7 @@ namespace RoboSharp
                     {
                         var file = new ProcessedFileInfo();
                         file.FileClass = "New Dir";
+                        file.FileClassType = FileClassType.NewDir;
                         long size;
                         long.TryParse(splitData[0].Replace("New Dir", "").Trim(), out size);
                         file.Size = size;
@@ -102,6 +103,7 @@ namespace RoboSharp
                     {
                         var file = new ProcessedFileInfo();
                         file.FileClass = splitData[0].Trim();
+                        file.FileClassType = FileClassType.File;
                         long size = 0;
                         long.TryParse(splitData[1].Trim(), out size);
                         file.Size = size;
@@ -134,6 +136,7 @@ namespace RoboSharp
                                 {
                                     var file = new ProcessedFileInfo();
                                     file.FileClass = "System Message";
+                                    file.FileClassType = FileClassType.SystemMessage;
                                     file.Size = 0;
                                     file.Name = data;
                                     OnFileProcessed(this, new FileProcessedEventArgs(file));


### PR DESCRIPTION
This small change helps clients when processing `ProcessedFileInfo` differently based on the kind of information (file, new directory or system message).