### PR TITLE
add configuration options

### DIFF
--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -21,6 +21,7 @@ namespace RoboSharp
         private SelectionOptions selectionOptions = new SelectionOptions();
         private RetryOptions retryOptions = new RetryOptions();
         private LoggingOptions loggingOptions = new LoggingOptions();
+        private RoboSharpConfiguration configuration = new RoboSharpConfiguration();
 
         #endregion Private Vars
 
@@ -46,6 +47,11 @@ namespace RoboSharp
         {
             get { return loggingOptions; }
             set { loggingOptions = value; }
+        }
+
+        public RoboSharpConfiguration Configuration
+        {
+            get { return configuration; }
         }
 
         #endregion Public Vars
@@ -111,7 +117,7 @@ namespace RoboSharp
                     }
                     else
                     {
-                        if (OnError != null && Regex.IsMatch(data, @" ERROR \d{1,3} \(0x\d{8}\) "))
+                        if (OnError != null && Regex.IsMatch(data, $" {Configuration.ErrorToken} " + @"\d{1,3} \(0x\d{8}\) "))
                         {
                             var errorCode = ApplicationConstants.ErrorCodes.FirstOrDefault(x => data.Contains(x.Key));
 
@@ -241,7 +247,7 @@ namespace RoboSharp
                 process.StartInfo.RedirectStandardError = true;
                 process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
                 process.StartInfo.CreateNoWindow = true;
-                process.StartInfo.FileName = "ROBOCOPY.exe";
+                process.StartInfo.FileName = Configuration.RoboCopyExe;
                 process.StartInfo.Arguments = GenerateParameters();
                 process.OutputDataReceived += process_OutputDataReceived;
                 process.ErrorDataReceived += process_ErrorDataReceived;

--- a/RoboSharp/RoboSharp.csproj
+++ b/RoboSharp/RoboSharp.csproj
@@ -60,6 +60,7 @@
     <Compile Include="RetryOptions.cs" />
     <Compile Include="RoboCommand.cs" />
     <Compile Include="RoboCommandCompletedEventArgs.cs" />
+    <Compile Include="RoboSharpConfiguration.cs" />
     <Compile Include="SelectionOptions.cs" />
     <Compile Include="StringExtensions.cs" />
     <Compile Include="VersionManager.cs" />

--- a/RoboSharp/RoboSharpConfiguration.cs
+++ b/RoboSharp/RoboSharpConfiguration.cs
@@ -1,0 +1,50 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace RoboSharp
+{
+    public class RoboSharpConfiguration
+    {
+        private static readonly IDictionary<string, RoboSharpConfiguration> 
+            defaultConfigurations = new Dictionary<string, RoboSharpConfiguration>()
+        {
+            {"en", new RoboSharpConfiguration { ErrorToken = "ERROR"} },
+            {"de", new RoboSharpConfiguration { ErrorToken = "FEHLER"} },
+        };
+
+        public string ErrorToken
+        {
+            get { return errorToken ?? GetDefaultConfiguration().ErrorToken; }
+            set { errorToken = value; }
+        }
+        private string errorToken = null;
+
+        public string RoboCopyExe
+        {
+            get { return roboCopyExe ?? "Robocopy.exe"; }
+            set { roboCopyExe = value; }
+        }
+        private string roboCopyExe = null;
+
+        private RoboSharpConfiguration GetDefaultConfiguration()
+        {
+            // check for default with language Tag xx-YY (e.g. en-US)
+            var currentLanguageTag = System.Globalization.CultureInfo.CurrentUICulture.IetfLanguageTag;
+            if (defaultConfigurations.ContainsKey(currentLanguageTag))
+                return defaultConfigurations[currentLanguageTag];
+
+            // check for default with language Tag xx (e.g. en)
+            var match = Regex.Match(currentLanguageTag, @"^\w+");
+            if (match.Success)
+            {
+                var currentMainLanguageTag = match.Value;
+                if (defaultConfigurations.ContainsKey(currentMainLanguageTag))
+                    return defaultConfigurations[currentMainLanguageTag];
+            }
+
+            // no match, fallback to en
+            return defaultConfigurations["en"];
+        }
+    }
+}


### PR DESCRIPTION
Add ability to configure settings like the Robocopy.exe to be used or language specific strings from robocopy output.

Usage: 
CopyCommand.Configuration.ErrorToken = "ERREUR"; // e.g. for french Robocopy
CopyCommand.Configuration.RoboCopyExe = @"C:\some\other\robocopy.exe";