### PR TITLE
Adding cancellationToken and removing null returns on validation

### DIFF
--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace RoboSharp


### PR DESCRIPTION
returning null on a task breaks continuewith model, using cancellation token allows for this model to not break, and provides the use of checking against TaskStatus to determine continuation action.