### PR TITLE
Set EnableRaisingEvents to trigger the "Exited" event.

### DIFF
--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -260,6 +260,7 @@ namespace RoboSharp
                 process.StartInfo.Arguments = GenerateParameters();
                 process.OutputDataReceived += process_OutputDataReceived;
                 process.ErrorDataReceived += process_ErrorDataReceived;
+                process.EnableRaisingEvents = true;
                 process.Exited += Process_Exited;
                 Debugger.Instance.DebugMessage("RoboCopy process started.");
                 process.Start();


### PR DESCRIPTION
Otherwise the Process_Exited() handler introduced in commit baf933e
will not fire at all, thus leading to a wrong setting of "hasExited"
and (worse) making subsequent calls to Stop() stall indefinitely.

The "Exited" event not firing can easily be verified by adding a debug
message to the handler method (not done in this PR to prevent tainting
the code base).