### PR TITLE
Fix #56: Change FileFilter to list and ensure proper quoting

### DIFF
--- a/RoboSharp.BackupApp/MainWindow.xaml.cs
+++ b/RoboSharp.BackupApp/MainWindow.xaml.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Linq;
 using System.Collections.ObjectModel;
 using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Collections.Generic;
 
 namespace RoboSharp.BackupApp
 {
@@ -53,7 +55,13 @@ namespace RoboSharp.BackupApp
             // copy options
             copy.CopyOptions.Source = Source.Text;
             copy.CopyOptions.Destination = Destination.Text;
-            copy.CopyOptions.FileFilter = FileFilter.Text;
+
+            // split user input by whitespace, mantaining those enclosed by quotes
+            var fileFilterItems = Regex.Matches(FileFilter.Text, @"[\""].+?[\""]|[^ ]+")
+                .Cast<Match>()
+                .Select(m => m.Value);
+
+            copy.CopyOptions.FileFilter = fileFilterItems;
             copy.CopyOptions.CopySubdirectories = CopySubDirectories.IsChecked ?? false;
             copy.CopyOptions.CopySubdirectoriesIncludingEmpty = CopySubdirectoriesIncludingEmpty.IsChecked ?? false;
             if (!string.IsNullOrWhiteSpace(Depth.Text))
@@ -82,7 +90,7 @@ namespace RoboSharp.BackupApp
                 copy.CopyOptions.MonitorSourceChangesLimit = Convert.ToInt32(MonitorSourceChangesLimit.Text);
             if (!string.IsNullOrWhiteSpace(MonitorSourceTimeLimit.Text))
                 copy.CopyOptions.MonitorSourceTimeLimit = Convert.ToInt32(MonitorSourceTimeLimit.Text);
-            
+
             // select options
             copy.SelectionOptions.OnlyCopyArchiveFiles = OnlyCopyArchiveFiles.IsChecked ?? false;
             copy.SelectionOptions.OnlyCopyArchiveFilesAndResetArchiveFlag = OnlyCopyArchiveFilesAndResetArchiveFlag.IsChecked ?? false;

--- a/RoboSharp/CopyOptions.cs
+++ b/RoboSharp/CopyOptions.cs
@@ -1,4 +1,7 @@
-﻿using System.Text;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
 namespace RoboSharp
 {
@@ -44,7 +47,7 @@ namespace RoboSharp
 
         #region Option Defaults
 
-        private string fileFilter = "*.*";
+        private IEnumerable<string> fileFilter = new[] { "*.*" };
         private string copyFlags = "DAT";
         private string directoryCopyFlags = VersionManager.Version >= 6.2 ? "DA" : "T";
 
@@ -63,9 +66,9 @@ namespace RoboSharp
         private string _destination;
         public string Destination { get { return _destination; } set { _destination = value.CleanDirectoryPath(); } }
         /// <summary>
-        /// Allows you to supply a specific file to copy or use wildcard characters (* or ?).
+        /// Allows you to supply a set of files to copy or use wildcard characters (* or ?).
         /// </summary>
-        public string FileFilter
+        public IEnumerable<string> FileFilter
         {
             get
             {
@@ -281,10 +284,16 @@ namespace RoboSharp
             var version = VersionManager.Version;
             var options = new StringBuilder();
 
-            // Set Source, Destination and FileFilter
+            // Set Source and Destination
             options.Append($"\"{Source}\" ");
             options.Append($"\"{Destination}\" ");
-            options.Append($"\"{FileFilter}\" ");
+
+            // Set FileFiltergit stq
+            // Quote each FileFilter item. The quotes are trimmed first to ensure that they are applied only once.
+            var fileFilterQuotedItems = FileFilter.Select(word => "\"" + word.Trim('"') + "\"");
+            string fileFilter = String.Join(" ", fileFilterQuotedItems);
+            options.Append($"{fileFilter} ");
+
             Debugger.Instance.DebugMessage(string.Format("Parsing CopyOptions progress ({0}).", options.ToString()));
 
             #region Set Options

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -272,7 +272,7 @@ namespace RoboSharp
                 Debugger.Instance.DebugMessage("RoboCopy process exited.");
             },cancellationToken, TaskCreationOptions.LongRunning, PriorityScheduler.BelowNormal);
 
-            backupTask.ContinueWith((continuation) =>
+            Task continueWithTask = backupTask.ContinueWith((continuation) =>
             {
                 if (!hasError)
                 {
@@ -286,7 +286,7 @@ namespace RoboSharp
                 Stop();
             }, cancellationToken);
 
-            return backupTask;
+            return continueWithTask;
         }
 
         void process_ErrorDataReceived(object sender, DataReceivedEventArgs e)


### PR DESCRIPTION
This fix changes `FileFilter` from `string` to `IEnumerable<string>` and ensures proper quoting. Given that it's a breaking change, I am considering marking `FileFilter` as obsolete and creating a new property `FileFilterList` instead.