### PR TITLE
Added General Output event. Catches every details possible

### DIFF
--- a/RoboSharp.BackupApp/MainWindow.xaml
+++ b/RoboSharp.BackupApp/MainWindow.xaml
@@ -225,6 +225,9 @@
             <TabItem Header="Errors" Name="ErrorsTab">
                 <DataGrid Name="ErrorGrid"></DataGrid>
             </TabItem>
+            <TabItem Header="Details" Name="DetailsTab">
+                <TextBlock Name="DetailsTextBlock"/>
+            </TabItem>
         </TabControl>
     </Grid>
 </Window>

--- a/RoboSharp.BackupApp/MainWindow.xaml.cs
+++ b/RoboSharp.BackupApp/MainWindow.xaml.cs
@@ -54,6 +54,7 @@ namespace RoboSharp.BackupApp
             copy.OnError += copy_OnError;
             copy.OnCopyProgressChanged += copy_OnCopyProgressChanged;
             copy.OnCommandCompleted += copy_OnCommandCompleted;
+            copy.OnGeneralOutputChanged += Copy_OnGeneralOutputChanged;
             // copy options
             copy.CopyOptions.Source = Source.Text;
             copy.CopyOptions.Destination = Destination.Text;
@@ -115,6 +116,14 @@ namespace RoboSharp.BackupApp
             copy.LoggingOptions.NoProgress = NoProgress.IsChecked ?? false;
 
             copy.Start();
+        }
+
+        private void Copy_OnGeneralOutputChanged(object sender, GeneralOutputEventArgs e)
+        {
+            Dispatcher.BeginInvoke((Action)(() =>
+            {
+                DetailsTextBlock.Text += $"{e.GeneralOutput}\n";
+            }));
         }
 
         void DebugMessage(object sender, Debugger.DebugMessageArgs e)

--- a/RoboSharp/GeneralOutputEventArgs.cs
+++ b/RoboSharp/GeneralOutputEventArgs.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace RoboSharp
+{
+	public class GeneralOutputEventArgs : EventArgs
+	{
+		public string GeneralOutput
+		{
+			get;
+			set;
+		}
+
+		public GeneralOutputEventArgs(string file)
+		{
+			GeneralOutput = file;
+		}
+	}
+}

--- a/RoboSharp/Interfaces/IRoboCommand.cs
+++ b/RoboSharp/Interfaces/IRoboCommand.cs
@@ -16,6 +16,7 @@ namespace RoboSharp.Interfaces
         event RoboCommand.ErrorHandler OnError;
         event RoboCommand.CommandCompletedHandler OnCommandCompleted;
         event RoboCommand.CopyProgressHandler OnCopyProgressChanged;
+        event RoboCommand.GeneralOutputHandler OnGeneralOutputChanged;
         void Pause();
         void Resume();
         Task Start(string domain = "", string username = "", string password = "");

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -77,6 +77,8 @@ namespace RoboSharp
         public event CommandCompletedHandler OnCommandCompleted;
         public delegate void CopyProgressHandler(object sender, CopyProgressEventArgs e);
         public event CopyProgressHandler OnCopyProgressChanged;
+        public delegate void GeneralOutputHandler(object sender, GeneralOutputEventArgs e);
+        public event GeneralOutputHandler OnGeneralOutputChanged;
 
         #endregion
 
@@ -168,6 +170,7 @@ namespace RoboSharp
                             }
                         }
                     }
+                    this.OnGeneralOutputChanged(this, new GeneralOutputEventArgs(e.Data.ToString()));
                 }
             }
         }
@@ -204,7 +207,7 @@ namespace RoboSharp
         {
             Debugger.Instance.DebugMessage("RoboCommand started execution.");
             hasError = false;
-            
+
             isRunning = true;
 
             var tokenSource = new CancellationTokenSource();


### PR DESCRIPTION
Added General Output event - this trigger the event for every single verbose robocopy is generating. 
Nice to have when you want to collect every single information being generated.

Added Tab under BackupApp to show details of copy being generated from General Output event.