### PR TITLE
Wrap log file paths in quotes if needed

### DIFF
--- a/RoboSharp/LoggingOptions.cs
+++ b/RoboSharp/LoggingOptions.cs
@@ -129,7 +129,7 @@ namespace RoboSharp
         public bool OutputAsUnicode { get; set; }
 
         /// <summary> Encase the LogPath in quotes if needed </summary>
-        internal string WrapPath(string logPath) => logPath.StartsWith("\"") ? logPath : logPath.Contains(" ") ? $"\"{logPath}\"" : logPath;
+        internal string WrapPath(string logPath) => ( !logPath.StartsWith("\"") && logPath.Contains(" ") ) ? $"\"{logPath}\"" : logPath;
         
         internal string Parse()
         {

--- a/RoboSharp/LoggingOptions.cs
+++ b/RoboSharp/LoggingOptions.cs
@@ -24,7 +24,7 @@ namespace RoboSharp
         internal const string NO_JOB_HEADER = "/NJH ";
         internal const string NO_JOB_SUMMARY = "/NJS ";
         internal const string OUTPUT_AS_UNICODE = "/UNICODE ";
-
+        
         /// <summary>
         /// Do not copy, timestamp or delete any files.
         /// [/L]
@@ -128,6 +128,9 @@ namespace RoboSharp
         /// </summary>
         public bool OutputAsUnicode { get; set; }
 
+        /// <summary> Encase the LogPath in quotes if needed </summary>
+        internal string WrapPath(string logPath) => logPath.StartsWith("\"") ? logPath : logPath.Contains(" ") ? $"\"{logPath}\"" : logPath;
+        
         internal string Parse()
         {
             var options = new StringBuilder();
@@ -157,13 +160,13 @@ namespace RoboSharp
             if (ShowEstimatedTimeOfArrival)
                 options.Append(SHOW_ESTIMATED_TIME_OF_ARRIVAL);
             if (!LogPath.IsNullOrWhiteSpace())
-                options.Append(string.Format(LOG_PATH, LogPath));
+                options.Append(string.Format(LOG_PATH, WrapPath(LogPath)));
             if (!AppendLogPath.IsNullOrWhiteSpace())
-                options.Append(string.Format(APPEND_LOG_PATH, AppendLogPath));
+                options.Append(string.Format(APPEND_LOG_PATH, WrapPath(AppendLogPath)));
             if (!UnicodeLogPath.IsNullOrWhiteSpace())
-                options.Append(string.Format(UNICODE_LOG_PATH, UnicodeLogPath));
+                options.Append(string.Format(UNICODE_LOG_PATH, WrapPath(UnicodeLogPath)));
             if (!AppendUnicodeLogPath.IsNullOrWhiteSpace())
-                options.Append(string.Format(APPEND_UNICODE_LOG_PATH, AppendUnicodeLogPath));
+                options.Append(string.Format(APPEND_UNICODE_LOG_PATH, WrapPath(AppendUnicodeLogPath)));
             if (OutputToRoboSharpAndLog)
                 options.Append(OUTPUT_TO_ROBOSHARP_AND_LOG);
             if (NoJobHeader)

--- a/RoboSharp/LoggingOptions.cs
+++ b/RoboSharp/LoggingOptions.cs
@@ -24,7 +24,7 @@ namespace RoboSharp
         internal const string NO_JOB_HEADER = "/NJH ";
         internal const string NO_JOB_SUMMARY = "/NJS ";
         internal const string OUTPUT_AS_UNICODE = "/UNICODE ";
-        
+
         /// <summary>
         /// Do not copy, timestamp or delete any files.
         /// [/L]


### PR DESCRIPTION
provides a function to wrap the log paths in quotes (required if user hasn't already done so in their string and if the path has spaces in it).
Without this, if a path with spaces is supplied, the task will silently fail