### PR TITLE
Update StringExtensions class

### DIFF
--- a/RoboSharp/StringExtensions.cs
+++ b/RoboSharp/StringExtensions.cs
@@ -1,8 +1,13 @@
 ﻿namespace RoboSharp
 {
-    public static class StringExtensions
+    /// <summary>
+    /// Static Class - Houses Extension Methods for strings
+    /// </summary>
+    internal static class StringExtensions
     {
-        public static bool IsNullOrWhiteSpace(this string value)
+        /// <remarks> Extension method provided by RoboSharp package </remarks>
+        /// <inheritdoc cref="System.String.IsNullOrWhiteSpace(string)"/>
+        internal static bool IsNullOrWhiteSpace(this string value)
         {
             if (value == null)
             {


### PR DESCRIPTION
Convert StringExtensions to Internal class instead of public - prevent outside packages seeing this extension method if declared using Robosharp namespace
If public is still preferred, added appropriate xml summary tags.

I was having an issue in my project due to using the robosharp namespace, which enabled this extension method. I thought the problem was with the method itself, but took some time to find out where it was being pulled from. 

Two-fold solution: 
- Modify the protection level to avoid outside projects seeing the extension method
- Add in summary tags to describe the method and declare that its being provided via the RoboSharp namespace