### PR TITLE
Create RoboCopyResultsList Object for Processing Multiple RoboCopyResults Objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ cmd.OnCommandCompleted += (args) =>
 cmd.Start();
 ```
 
+N.B. The below has been superseded by changes in PR #127 - documentation will be updated shortly to cover all new methods
+
 .AddStatistic
 
 This is useful if you are running multiple RoboCopy tasks as it allows you to add all the statistics to each other to generating overall results
@@ -145,8 +147,6 @@ void copy_OnCommandCompleted(object sender, RoboCommandCompletedEventArgs e)
             }));
         }
 ```
-
-N.B. The below has been superseded by changes in PR #127 - documentation will be updated shortly to cover all new methods
 
 .AverageStatistics
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ void backup_OnCommandCompleted(object sender, RoboCommandCompletedEventArgs e)
 }
 ```
 
-Extended Results:
+#### Extended Results:
 
 See below examples on how to access the extended results where you can get total, copied, skipped, mismatch, failed and extra statistics for directories and files and bytes, as well as additional speed info e.g. bytes per sec and megabytes per minute
 
@@ -101,6 +101,72 @@ cmd.OnCommandCompleted += (args) =>
 }
 cmd.Start();
 ```
+
+.AddStatistic
+
+This is useful if you are running multiple RoboCopy tasks as it allows you to add all the statistics to each other to generating overall results
+
+```c#
+RoboSharp.Results.Statistic FileStats = new RoboSharp.Results.Statistic();
+RoboSharp.Results.Statistic DirStats = new RoboSharp.Results.Statistic();
+
+test = new RoboCommand();
+
+// Run first task and add results
+test.CopyOptions.Source = @"C:\SOURCE_1";
+test.CopyOptions.Destination = @"C:\DESTINATION";
+
+RoboSharp.Results.RoboCopyResults results1 = await test.StartAsync();
+
+FileStats.AddStatistic(results1.FilesStatistic);
+DirStats.AddStatistic(results1.DirectoriesStatistic);
+
+// Run second task and add results
+test.CopyOptions.Source = @"C:\SOURCE_2";
+test.CopyOptions.Destination = @"C:\DESTINATION";
+
+RoboSharp.Results.RoboCopyResults results2 = await test.StartAsync();
+
+FileStats.AddStatistic(results2.FilesStatistic);
+DirStats.AddStatistic(results2.DirectoriesStatistic);
+```
+
+You could also use .AddStatistic in the OnCommandCompleted event e.g.
+
+```c#
+void copy_OnCommandCompleted(object sender, RoboCommandCompletedEventArgs e)
+        {
+            this.BeginInvoke((Action)(() =>
+            {
+                // Get robocopy results 
+                RoboSharp.Results.RoboCopyResults AnalysisResults = e.Results;
+
+                FileStats.AddStatistic(AnalysisResults.FilesStatistic);
+            }));
+        }
+```
+
+
+N.B. The below has been superseded by changes in PR #127 - documentation will be updated shortly to cover all new methods
+
+.AverageStatistics
+
+Again if running multiple RoboCopy tasks you can use this to get average results for BytesPerSec and MegaBytesPerMin 
+
+Based on above example
+
+```c#
+// Call Static Method to return new object with the average
+RoboSharp.Results.SpeedStatistic avg = RoboSharp.Results.SpeedStatistic.AverageStatistics(new RoboSharp.Results.SpeedStatistic[] { results1.SpeedStatistic, results2.SpeedStatistic });
+```
+
+or
+
+```c#
+// Result1 will now store the average statistic value. Result 2 can be disposed or or re-used for additional RoboCopy commands.
+results1.AverageStatistic(results2);
+```
+
 =======
 
 # Contributing to RoboSharp

--- a/RoboSharp.BackupApp/MainWindow.xaml
+++ b/RoboSharp.BackupApp/MainWindow.xaml
@@ -202,7 +202,7 @@
                             </Expander>
                         </StackPanel>
                     </ScrollViewer>
-                    
+
                     <Button Content="Backup" HorizontalAlignment="Right" Margin="0,0,10,10" VerticalAlignment="Bottom" Width="75" Click="Button_Click"/>
                 </Grid>
             </TabItem>
@@ -225,11 +225,12 @@
             <TabItem Header="Errors" Name="ErrorsTab">
                 <DataGrid Name="ErrorGrid"></DataGrid>
             </TabItem>
-            <TabItem Header="TabItem" HorizontalAlignment="Left" Height="20" VerticalAlignment="Top" Width="57">
+            <TabItem Header="Job History" HorizontalAlignment="Left" Height="20" VerticalAlignment="Top" Width="57">
                 <Grid x:Name="ResultsListGrid" Background="#FFE5E5E5">
-                    <ListBox x:Name="ListBox_JobResults" HorizontalAlignment="Left" Height="320" Margin="10,10,0,0" VerticalAlignment="Top" Width="241" SelectionChanged="UpdateSelectedItemsLabel"/>
-                    <Label x:Name="lbl_OveralTotals" Content="Label" HorizontalAlignment="Left" Height="123" Margin="256,10,0,0" VerticalAlignment="Top" Width="234"/>
-                    <Label x:Name="lbl_SelectedItemTotals" Content="Label" HorizontalAlignment="Left" Height="123" Margin="256,197,0,0" VerticalAlignment="Top" Width="234"/>
+                    <ListBox x:Name="ListBox_JobResults" HorizontalAlignment="Left" Height="320" Margin="10,54,0,0" VerticalAlignment="Top" Width="241" SelectionChanged="UpdateSelectedItemsLabel"/>
+                    <Label x:Name="lbl_OveralTotals" Content="Total History Results" HorizontalAlignment="Left" Height="123" Margin="256,187,0,0" VerticalAlignment="Top" Width="234"/>
+                    <Label x:Name="lbl_SelectedItemTotals" Content="Selected Job Results" HorizontalAlignment="Left" Height="123" Margin="256,59,0,0" VerticalAlignment="Top" Width="234"/>
+                    <Label x:Name="lbl_OveralTotals_Copy" Content="This tab contains a list of the results from all previous runs during this session." HorizontalAlignment="Left" Height="44" Margin="10,10,0,0" VerticalAlignment="Top" Width="669"/>
                 </Grid>
             </TabItem>
         </TabControl>

--- a/RoboSharp.BackupApp/MainWindow.xaml
+++ b/RoboSharp.BackupApp/MainWindow.xaml
@@ -228,7 +228,7 @@
             <TabItem Header="Job History" HorizontalAlignment="Left" Height="20" VerticalAlignment="Center" Width="94" Margin="-2,0,0,0">
                 <Grid x:Name="ResultsListGrid" Background="#FFE5E5E5">
                     <ListBox x:Name="ListBox_JobResults" HorizontalAlignment="Left" Height="320" Margin="10,54,0,0" VerticalAlignment="Top" Width="321" SelectionChanged="UpdateSelectedItemsLabel"/>
-                    <Label x:Name="lbl_OverallTotals" Content="Total History Results" HorizontalAlignment="Left" Height="123" Margin="336,251,0,0" VerticalAlignment="Top" Width="367"/>
+                    <Label x:Name="lbl_OverallTotals" Content="Total History Results" HorizontalAlignment="Left" Height="179" Margin="336,251,0,0" VerticalAlignment="Top" Width="367"/>
                     <Label x:Name="lbl_SelectedItemTotals" Content="Selected Job Results" HorizontalAlignment="Left" Height="192" Margin="336,54,0,0" VerticalAlignment="Top" Width="367"/>
                     <Label x:Name="lbl_JobHistoryHeader" Content="This tab contains a list of the results from all previous runs during this session." HorizontalAlignment="Left" Height="44" Margin="10,10,0,0" VerticalAlignment="Top" Width="669"/>
                 </Grid>

--- a/RoboSharp.BackupApp/MainWindow.xaml
+++ b/RoboSharp.BackupApp/MainWindow.xaml
@@ -225,12 +225,12 @@
             <TabItem Header="Errors" Name="ErrorsTab">
                 <DataGrid Name="ErrorGrid"></DataGrid>
             </TabItem>
-            <TabItem Header="Job History" HorizontalAlignment="Left" Height="20" VerticalAlignment="Top" Width="57">
+            <TabItem Header="Job History" HorizontalAlignment="Left" Height="20" VerticalAlignment="Top" Width="94" Margin="-2,-2,-35,0">
                 <Grid x:Name="ResultsListGrid" Background="#FFE5E5E5">
                     <ListBox x:Name="ListBox_JobResults" HorizontalAlignment="Left" Height="320" Margin="10,54,0,0" VerticalAlignment="Top" Width="241" SelectionChanged="UpdateSelectedItemsLabel"/>
-                    <Label x:Name="lbl_OveralTotals" Content="Total History Results" HorizontalAlignment="Left" Height="123" Margin="256,187,0,0" VerticalAlignment="Top" Width="234"/>
-                    <Label x:Name="lbl_SelectedItemTotals" Content="Selected Job Results" HorizontalAlignment="Left" Height="123" Margin="256,59,0,0" VerticalAlignment="Top" Width="234"/>
-                    <Label x:Name="lbl_OveralTotals_Copy" Content="This tab contains a list of the results from all previous runs during this session." HorizontalAlignment="Left" Height="44" Margin="10,10,0,0" VerticalAlignment="Top" Width="669"/>
+                    <Label x:Name="lbl_OverallTotals" Content="Total History Results" HorizontalAlignment="Left" Height="123" Margin="256,187,0,0" VerticalAlignment="Top" Width="367"/>
+                    <Label x:Name="lbl_SelectedItemTotals" Content="Selected Job Results" HorizontalAlignment="Left" Height="123" Margin="256,59,0,0" VerticalAlignment="Top" Width="367"/>
+                    <Label x:Name="lbl_JobHistoryHeader" Content="This tab contains a list of the results from all previous runs during this session." HorizontalAlignment="Left" Height="44" Margin="10,10,0,0" VerticalAlignment="Top" Width="669"/>
                 </Grid>
             </TabItem>
         </TabControl>

--- a/RoboSharp.BackupApp/MainWindow.xaml
+++ b/RoboSharp.BackupApp/MainWindow.xaml
@@ -225,11 +225,11 @@
             <TabItem Header="Errors" Name="ErrorsTab">
                 <DataGrid Name="ErrorGrid"></DataGrid>
             </TabItem>
-            <TabItem Header="Job History" HorizontalAlignment="Left" Height="20" VerticalAlignment="Top" Width="94" Margin="-2,-2,-35,0">
+            <TabItem Header="Job History" HorizontalAlignment="Left" Height="20" VerticalAlignment="Center" Width="94" Margin="-2,0,0,0">
                 <Grid x:Name="ResultsListGrid" Background="#FFE5E5E5">
-                    <ListBox x:Name="ListBox_JobResults" HorizontalAlignment="Left" Height="320" Margin="10,54,0,0" VerticalAlignment="Top" Width="241" SelectionChanged="UpdateSelectedItemsLabel"/>
-                    <Label x:Name="lbl_OverallTotals" Content="Total History Results" HorizontalAlignment="Left" Height="123" Margin="256,187,0,0" VerticalAlignment="Top" Width="367"/>
-                    <Label x:Name="lbl_SelectedItemTotals" Content="Selected Job Results" HorizontalAlignment="Left" Height="123" Margin="256,59,0,0" VerticalAlignment="Top" Width="367"/>
+                    <ListBox x:Name="ListBox_JobResults" HorizontalAlignment="Left" Height="320" Margin="10,54,0,0" VerticalAlignment="Top" Width="321" SelectionChanged="UpdateSelectedItemsLabel"/>
+                    <Label x:Name="lbl_OverallTotals" Content="Total History Results" HorizontalAlignment="Left" Height="123" Margin="336,251,0,0" VerticalAlignment="Top" Width="367"/>
+                    <Label x:Name="lbl_SelectedItemTotals" Content="Selected Job Results" HorizontalAlignment="Left" Height="192" Margin="336,54,0,0" VerticalAlignment="Top" Width="367"/>
                     <Label x:Name="lbl_JobHistoryHeader" Content="This tab contains a list of the results from all previous runs during this session." HorizontalAlignment="Left" Height="44" Margin="10,10,0,0" VerticalAlignment="Top" Width="669"/>
                 </Grid>
             </TabItem>

--- a/RoboSharp.BackupApp/MainWindow.xaml
+++ b/RoboSharp.BackupApp/MainWindow.xaml
@@ -225,6 +225,13 @@
             <TabItem Header="Errors" Name="ErrorsTab">
                 <DataGrid Name="ErrorGrid"></DataGrid>
             </TabItem>
+            <TabItem Header="TabItem" HorizontalAlignment="Left" Height="20" VerticalAlignment="Top" Width="57">
+                <Grid x:Name="ResultsListGrid" Background="#FFE5E5E5">
+                    <ListBox x:Name="ListBox_JobResults" HorizontalAlignment="Left" Height="320" Margin="10,10,0,0" VerticalAlignment="Top" Width="241" SelectionChanged="UpdateSelectedItemsLabel"/>
+                    <Label x:Name="lbl_OveralTotals" Content="Label" HorizontalAlignment="Left" Height="123" Margin="256,10,0,0" VerticalAlignment="Top" Width="234"/>
+                    <Label x:Name="lbl_SelectedItemTotals" Content="Label" HorizontalAlignment="Left" Height="123" Margin="256,197,0,0" VerticalAlignment="Top" Width="234"/>
+                </Grid>
+            </TabItem>
         </TabControl>
     </Grid>
 </Window>

--- a/RoboSharp.BackupApp/MainWindow.xaml
+++ b/RoboSharp.BackupApp/MainWindow.xaml
@@ -231,6 +231,7 @@
                     <Label x:Name="lbl_OverallTotals" Content="Total History Results" HorizontalAlignment="Left" Height="179" Margin="336,251,0,0" VerticalAlignment="Top" Width="367"/>
                     <Label x:Name="lbl_SelectedItemTotals" Content="Selected Job Results" HorizontalAlignment="Left" Height="192" Margin="336,54,0,0" VerticalAlignment="Top" Width="367"/>
                     <Label x:Name="lbl_JobHistoryHeader" Content="This tab contains a list of the results from all previous runs during this session." HorizontalAlignment="Left" Height="44" Margin="10,10,0,0" VerticalAlignment="Top" Width="669"/>
+                    <Button Content="Remove Selected" HorizontalAlignment="Left" Margin="37,394,0,0" VerticalAlignment="Top" Click="Remove_Selected_Click"/>
                 </Grid>
             </TabItem>
         </TabControl>

--- a/RoboSharp.BackupApp/MainWindow.xaml.cs
+++ b/RoboSharp.BackupApp/MainWindow.xaml.cs
@@ -255,7 +255,7 @@ namespace RoboSharp.BackupApp
         private void UpdateOverallLabel(object sender, EventArgs e)
         {
             string NL = Environment.NewLine;
-            lbl_OveralTotals.Content = $"Job History:" +
+            lbl_OverallTotals.Content = $"Job History:" +
                 $"{NL}Total Directories: {JobResults.DirectoriesStatistic.Total}" +
                 $"{NL}Total Files: {JobResults.FilesStatistic.Total}" +
                 $"{NL}Total Size (bytes): {JobResults.BytesStatistic.Total}" +

--- a/RoboSharp.BackupApp/MainWindow.xaml.cs
+++ b/RoboSharp.BackupApp/MainWindow.xaml.cs
@@ -244,7 +244,7 @@ namespace RoboSharp.BackupApp
                 $"{NL}Total Directories: {result.DirectoriesStatistic.Total}" +
                 $"{NL}Total Files: {result.FilesStatistic.Total}" +
                 $"{NL}Total Size (bytes): {result.BytesStatistic.Total}" +
-                $"{NL}Status: {result.Status.ToString()}";
+                $"{NL}{result.Status.ToString()}";
         }
 
         /// <summary>
@@ -259,8 +259,7 @@ namespace RoboSharp.BackupApp
                 $"{NL}Total Directories: {JobResults.DirectoriesStatistic.Total}" +
                 $"{NL}Total Files: {JobResults.FilesStatistic.Total}" +
                 $"{NL}Total Size (bytes): {JobResults.BytesStatistic.Total}" +
-                $"{NL}Status: {JobResults.Status.ToString()}";
-            ListBox_JobResults.Items.Refresh();
+                $"{NL}{JobResults.Status.ToString()}";
         }
     }
 

--- a/RoboSharp.BackupApp/MainWindow.xaml.cs
+++ b/RoboSharp.BackupApp/MainWindow.xaml.cs
@@ -170,7 +170,7 @@ namespace RoboSharp.BackupApp
             {
                 OptionsGrid.IsEnabled = true;
                 ProgressGrid.IsEnabled = false;
-                
+
                 var results = e.Results;
                 Console.WriteLine("Files copied: " + results.FilesStatistic.Copied);
                 Console.WriteLine("Directories copied: " + results.DirectoriesStatistic.Copied);
@@ -246,6 +246,8 @@ namespace RoboSharp.BackupApp
                 $"{NL}Total Directories: {result.DirectoriesStatistic.Total}" +
                 $"{NL}Total Files: {result.FilesStatistic.Total}" +
                 $"{NL}Total Size (bytes): {result.BytesStatistic.Total}" +
+                $"{NL}Speed (Bytes/Second): {result?.SpeedStatistic?.BytesPerSec ?? 0}" +
+                $"{NL}Speed (MB/Min): {result?.SpeedStatistic?.MegaBytesPerMin ?? 0}" +
                 $"{NL}{result.Status.ToString()}";
         }
 
@@ -261,6 +263,8 @@ namespace RoboSharp.BackupApp
                 $"{NL}Total Directories: {JobResults.DirectoriesStatistic.Total}" +
                 $"{NL}Total Files: {JobResults.FilesStatistic.Total}" +
                 $"{NL}Total Size (bytes): {JobResults.BytesStatistic.Total}" +
+                $"{NL}Speed (Bytes/Second): {JobResults.SpeedStatistic.BytesPerSec}" +
+                $"{NL}Speed (MB/Min): {JobResults.SpeedStatistic.MegaBytesPerMin}" +
                 $"{NL}Any Jobs Cancelled: {(JobResults.Status.WasCancelled ? "YES" : "NO")}" +
                 $"{NL}{JobResults.Status.ToString()}";
         }

--- a/RoboSharp.BackupApp/MainWindow.xaml.cs
+++ b/RoboSharp.BackupApp/MainWindow.xaml.cs
@@ -241,16 +241,16 @@ namespace RoboSharp.BackupApp
             Results.RoboCopyResults result = (Results.RoboCopyResults)this.ListBox_JobResults.SelectedItem;
             string NL = Environment.NewLine;
             lbl_SelectedItemTotals.Content = $"Selected Job:" +
-                $"{NL}Source: {result.Source}" +
-                $"{NL}Destination: {result.Destination}" +
+                $"{NL}Source: {result?.Source ?? ""}" +
+                $"{NL}Destination: {result?.Destination ?? ""}" +
                 $"{NL}Total Directories: {result?.DirectoriesStatistic?.Total ?? 0}" +
                 $"{NL}Total Files: {result?.FilesStatistic?.Total ?? 0}" +
                 $"{NL}Total Size (bytes): {result?.BytesStatistic?.Total ?? 0}" +
                 $"{NL}Speed (Bytes/Second): {result?.SpeedStatistic?.BytesPerSec ?? 0}" +
                 $"{NL}Speed (MB/Min): {result?.SpeedStatistic?.MegaBytesPerMin ?? 0}" +
-                $"{NL}{result.Status.ToString()}";
+                $"{NL}{result?.Status.ToString() ?? ""}";
         }
-
+        
         /// <summary>
         /// Runs every time the JobResults list is updated.
         /// </summary>
@@ -268,6 +268,15 @@ namespace RoboSharp.BackupApp
                 $"{NL}Any Jobs Cancelled: {(JobResults.Status.WasCancelled ? "YES" : "NO")}" +
                 $"{NL}{JobResults.Status.ToString()}";
         }
+
+        private void Remove_Selected_Click(object sender, RoutedEventArgs e)
+        {
+            Results.RoboCopyResults result = (Results.RoboCopyResults)this.ListBox_JobResults.SelectedItem;
+
+            JobResults.Remove(result);
+                       
+        }
+
     }
 
     public class FileError

--- a/RoboSharp.BackupApp/MainWindow.xaml.cs
+++ b/RoboSharp.BackupApp/MainWindow.xaml.cs
@@ -24,7 +24,7 @@ namespace RoboSharp.BackupApp
         {
             InitializeComponent();
             this.Closing += MainWindow_Closing;
-            JobResults.ListModification += UpdateOverallLabel;
+            JobResults.CollectionChanged += UpdateOverallLabel;
             ListBox_JobResults.ItemsSource = JobResults;
             ErrorGrid.ItemsSource = Errors;
             VersionManager.VersionCheck = VersionManager.VersionCheckType.UseWMI;
@@ -247,6 +247,11 @@ namespace RoboSharp.BackupApp
                 $"{NL}Status: {result.Status.ToString()}";
         }
 
+        /// <summary>
+        /// Runs every time the JobResults list is updated.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void UpdateOverallLabel(object sender, EventArgs e)
         {
             string NL = Environment.NewLine;
@@ -255,6 +260,7 @@ namespace RoboSharp.BackupApp
                 $"{NL}Total Files: {JobResults.FilesStatistic.Total}" +
                 $"{NL}Total Size (bytes): {JobResults.BytesStatistic.Total}" +
                 $"{NL}Status: {JobResults.Status.ToString()}";
+            ListBox_JobResults.Items.Refresh();
         }
     }
 

--- a/RoboSharp.BackupApp/MainWindow.xaml.cs
+++ b/RoboSharp.BackupApp/MainWindow.xaml.cs
@@ -243,9 +243,9 @@ namespace RoboSharp.BackupApp
             lbl_SelectedItemTotals.Content = $"Selected Job:" +
                 $"{NL}Source: {result.Source}" +
                 $"{NL}Destination: {result.Destination}" +
-                $"{NL}Total Directories: {result.DirectoriesStatistic.Total}" +
-                $"{NL}Total Files: {result.FilesStatistic.Total}" +
-                $"{NL}Total Size (bytes): {result.BytesStatistic.Total}" +
+                $"{NL}Total Directories: {result?.DirectoriesStatistic?.Total ?? 0}" +
+                $"{NL}Total Files: {result?.FilesStatistic?.Total ?? 0}" +
+                $"{NL}Total Size (bytes): {result?.BytesStatistic?.Total ?? 0}" +
                 $"{NL}Speed (Bytes/Second): {result?.SpeedStatistic?.BytesPerSec ?? 0}" +
                 $"{NL}Speed (MB/Min): {result?.SpeedStatistic?.MegaBytesPerMin ?? 0}" +
                 $"{NL}{result.Status.ToString()}";

--- a/RoboSharp.BackupApp/MainWindow.xaml.cs
+++ b/RoboSharp.BackupApp/MainWindow.xaml.cs
@@ -241,6 +241,8 @@ namespace RoboSharp.BackupApp
             Results.RoboCopyResults result = (Results.RoboCopyResults)this.ListBox_JobResults.SelectedItem;
             string NL = Environment.NewLine;
             lbl_SelectedItemTotals.Content = $"Selected Job:" +
+                $"{NL}Source: {result.Source}" +
+                $"{NL}Destination: {result.Destination}" +
                 $"{NL}Total Directories: {result.DirectoriesStatistic.Total}" +
                 $"{NL}Total Files: {result.FilesStatistic.Total}" +
                 $"{NL}Total Size (bytes): {result.BytesStatistic.Total}" +

--- a/RoboSharp.BackupApp/MainWindow.xaml.cs
+++ b/RoboSharp.BackupApp/MainWindow.xaml.cs
@@ -274,7 +274,15 @@ namespace RoboSharp.BackupApp
             Results.RoboCopyResults result = (Results.RoboCopyResults)this.ListBox_JobResults.SelectedItem;
 
             JobResults.Remove(result);
-                       
+
+            {
+                if (ListBox_JobResults.Items.Count == 0)
+                {
+                    lbl_OverallTotals.Content = "";
+                    lbl_SelectedItemTotals.Content = "";
+                }
+            }
+
         }
 
     }

--- a/RoboSharp.BackupApp/MainWindow.xaml.cs
+++ b/RoboSharp.BackupApp/MainWindow.xaml.cs
@@ -259,6 +259,7 @@ namespace RoboSharp.BackupApp
                 $"{NL}Total Directories: {JobResults.DirectoriesStatistic.Total}" +
                 $"{NL}Total Files: {JobResults.FilesStatistic.Total}" +
                 $"{NL}Total Size (bytes): {JobResults.BytesStatistic.Total}" +
+                $"{NL}Any Jobs Cancelled: {(JobResults.Status.WasCancelled ? "YES" : "NO")}" +
                 $"{NL}{JobResults.Status.ToString()}";
         }
     }

--- a/RoboSharp.BackupApp/MainWindow.xaml.cs
+++ b/RoboSharp.BackupApp/MainWindow.xaml.cs
@@ -18,10 +18,14 @@ namespace RoboSharp.BackupApp
 
         public ObservableCollection<FileError> Errors = new ObservableCollection<FileError>();
 
+        private Results.RoboCopyResultsList JobResults = new Results.RoboCopyResultsList();
+
         public MainWindow()
         {
             InitializeComponent();
             this.Closing += MainWindow_Closing;
+            JobResults.ListModification += UpdateOverallLabel;
+            ListBox_JobResults.ItemsSource = JobResults;
             ErrorGrid.ItemsSource = Errors;
             VersionManager.VersionCheck = VersionManager.VersionCheckType.UseWMI;
             var v = VersionManager.Version;
@@ -170,6 +174,7 @@ namespace RoboSharp.BackupApp
                 var results = e.Results;
                 Console.WriteLine("Files copied: " + results.FilesStatistic.Copied);
                 Console.WriteLine("Directories copied: " + results.DirectoriesStatistic.Copied);
+                JobResults.Add(e.Results);
             }));
         }
 
@@ -229,6 +234,27 @@ namespace RoboSharp.BackupApp
                 copy.Stop();
                 copy.Dispose();
             }
+        }
+
+        private void UpdateSelectedItemsLabel(object sender, SelectionChangedEventArgs e)
+        {
+            Results.RoboCopyResults result = (Results.RoboCopyResults)this.ListBox_JobResults.SelectedItem;
+            string NL = Environment.NewLine;
+            lbl_SelectedItemTotals.Content = $"Selected Job:" +
+                $"{NL}Total Directories: {result.DirectoriesStatistic.Total}" +
+                $"{NL}Total Files: {result.FilesStatistic.Total}" +
+                $"{NL}Total Size (bytes): {result.BytesStatistic.Total}" +
+                $"{NL}Status: {result.Status.ToString()}";
+        }
+
+        private void UpdateOverallLabel(object sender, EventArgs e)
+        {
+            string NL = Environment.NewLine;
+            lbl_OveralTotals.Content = $"Job History:" +
+                $"{NL}Total Directories: {JobResults.DirectoriesStatistic.Total}" +
+                $"{NL}Total Files: {JobResults.FilesStatistic.Total}" +
+                $"{NL}Total Size (bytes): {JobResults.BytesStatistic.Total}" +
+                $"{NL}Status: {JobResults.Status.ToString()}";
         }
     }
 

--- a/RoboSharp/GenericListWithEvents.cs
+++ b/RoboSharp/GenericListWithEvents.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Collections.Specialized;
 
 namespace System.Collections.Generic
 {
@@ -7,18 +8,18 @@ namespace System.Collections.Generic
     /// Extends the Generic <see cref="List{T}"/> class with an event that will fire when the list is updated.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class ListWithEvents<T> : List<T>
+    public class ObservableList<T> : List<T>, INotifyCollectionChanged
     {
         #region < Constructors >
 
         ///<inheritdoc cref="List{T}()"/>
-        public ListWithEvents() : base() { }
+        public ObservableList() : base() { }
 
         ///<inheritdoc cref="List{T}(int)"/>
-        public ListWithEvents(int capacity) : base(capacity) { }
+        public ObservableList(int capacity) : base(capacity) { }
 
         ///<inheritdoc cref="List{T}(IEnumerable{T})"/>
-        public ListWithEvents(IEnumerable<T> collection) : base(collection) { }
+        public ObservableList(IEnumerable<T> collection) : base(collection) { }
 
         #endregion
 
@@ -29,60 +30,22 @@ namespace System.Collections.Generic
         #region < Events >
 
         /// <summary>
-        /// Event Args for the <see cref="ListWithEvents{T}.ListModification"/> event. <br/>
-        /// Reports what items have been added / removed from the list.
-        /// </summary>
-        public class ListModificationEventArgs : EventArgs
-        {
-            /// <summary>Create new instance of <see cref="ListModificationEventArgs"/></summary>
-            /// <param name="Item">Single Item Added/Removed from the list</param>
-            /// <param name="Added">
-            /// TRUE: Item(s) added to the <see cref="ItemsAdded"/> property. <br/>
-            /// FALSE: Item(s) added to the <see cref="ItemsRemoved"/> property. <br/>
-            /// </param>
-            public ListModificationEventArgs(T Item, bool Added) 
-            { 
-                this.ItemsAdded = Added ? new T[] { Item } : new T[] { };
-                this.ItemsRemoved = !Added ? new T[] { Item } : new T[] { };
-            }
-
-#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do) -> Inherits the parameter description, but VS isn't smart enough to see it
-            /// <param name="collection">Collection of items added / removed from the list.</param>
-            /// <inheritdoc cref="ListModificationEventArgs.ListModificationEventArgs(T, bool)"/>            
-            public ListModificationEventArgs(IEnumerable<T> collection, bool Added)
-            { 
-                this.ItemsAdded = Added ? collection.ToArray() : new T[] { };
-                this.ItemsRemoved = !Added ? collection.ToArray() : new T[] { };
-            }
-#pragma warning restore CS1573
-
-            /// <summary> Array of items that were added to the list. </summary>
-            public T[] ItemsAdded { get; private set; }
-
-            /// <summary> Array of items that were removed from the list. </summary>
-            public T[] ItemsRemoved { get; private set; }
-        }
-
-        /// <summary>
-        /// Raise the <see cref="ListModification"/> event. <para/>
+        /// Raise the <see cref="CollectionChanged"/> event. <para/>
         /// Override this method to provide post-processing of Added/Removed items within derived classes. <br/>
-        /// <see cref="HasEventListener_ListModification"/> may need to be overridden to allow post-processing.
+        /// <see cref="HasEventListener_CollectionChanged"/> may need to be overridden to allow post-processing.
         /// </summary>
         /// <param name="e"></param>
-        protected virtual void OnListModification(ListModificationEventArgs e) => ListModification?.Invoke(this, e);
+        protected virtual void OnCollectionChanged(NotifyCollectionChangedEventArgs e) => CollectionChanged?.Invoke(this, e);
 
         /// <summary>
-        /// Boolean check that optimizes the Remove*/Clear methods if the ListModification Event has no listeners. (No need to collect information on removed items if not reacting to the event)
-        /// <para/>Override this method if you always wish to grab the removed items for processing during <see cref="OnListModification(ListModificationEventArgs)"/>
+        /// Boolean check that optimizes the Remove*/Clear methods if the CollectionChanged Event has no listeners. (No need to collect information on removed items if not reacting to the event)
+        /// <para/>Override this method if you always wish to grab the removed items for processing during <see cref="OnCollectionChanged(NotifyCollectionChangedEventArgs)"/>
         /// </summary>
-        /// <returns>Result of: ( <see cref="ListModification"/> != null ) </returns>
-        protected virtual bool HasEventListener_ListModification() { return ListModification != null; }
+        /// <returns>Result of: ( <see cref="CollectionChanged"/> != null ) </returns>
+        protected virtual bool HasEventListener_CollectionChanged() { return CollectionChanged != null; }
 
-        /// <summary> 
-        /// This event fires whenever the List's array is updated. 
-        /// <br/> The event will not fire when a new list is constructed/initialized, only when items are added or removed.
-        /// </summary>
-        public event EventHandler<ListModificationEventArgs> ListModification;
+        /// <summary> This event fires whenever the List's array is updated. </summary>
+        public event NotifyCollectionChangedEventHandler CollectionChanged;
 
         #endregion
 
@@ -92,29 +55,29 @@ namespace System.Collections.Generic
         new public void Insert(int index, T item)
         {
             base.Insert(index, item);
-            OnListModification(new ListModificationEventArgs(item, true));
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, index: index));
         }
 
         ///<inheritdoc cref="List{T}.Add(T)"/>
         new public void Add(T item)
         {
             base.Add(item);
-            OnListModification(new ListModificationEventArgs(item, true));
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item));
         }
 
         ///<inheritdoc cref="System.Collections.Generic.List{T}.AddRange(IEnumerable{T})"/>
         new public void AddRange(IEnumerable<T> collection)
         {
             base.AddRange(collection);
-            OnListModification(new ListModificationEventArgs(collection, true));
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, collection.ToList()));
         }
 
         ///<inheritdoc cref="List{T}.Clear"/>
         new public void Clear()
         {
-            T[] arglist = HasEventListener_ListModification() ? base.ToArray() : null;
+            T[] removedItems = HasEventListener_CollectionChanged() ? base.ToArray() : null;
             base.Clear();
-            OnListModification(new ListModificationEventArgs(arglist, false));
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset, newItems: new List<T>(), oldItems: removedItems.ToList()));
         }
 
         ///<inheritdoc cref="List{T}.Remove(T)"/>
@@ -122,7 +85,7 @@ namespace System.Collections.Generic
         {
             if (base.Remove(item))
             {
-                OnListModification(new ListModificationEventArgs(item, false));
+                OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item));
                 return true;
             }
             else
@@ -132,17 +95,17 @@ namespace System.Collections.Generic
         ///<inheritdoc cref="List{T}.RemoveAt(int)"/>
         new public void RemoveAt(int index)
         {
-            T item = HasEventListener_ListModification() ? base[index] : default;
+            T item = HasEventListener_CollectionChanged() ? base[index] : default;
             base.RemoveAt(index);
-            OnListModification(new ListModificationEventArgs(item, false));
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, index: index));
         }
 
         ///<inheritdoc cref="List{T}.RemoveRange(int,int)"/>
         new public void RemoveRange(int index, int count)
         {
-            List<T> arglist = HasEventListener_ListModification() ? base.GetRange(index, count) : null;
+            List<T> removedItems = HasEventListener_CollectionChanged() ? base.GetRange(index, count) : null;
             base.RemoveRange(index, count);
-            OnListModification(new ListModificationEventArgs(arglist, false));
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset, newItems: new List<T>(), oldItems: removedItems.ToList()));
         }
 
         #endregion

--- a/RoboSharp/GenericListWithEvents.cs
+++ b/RoboSharp/GenericListWithEvents.cs
@@ -1,0 +1,150 @@
+﻿using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace System.Collections.Generic
+{
+    /// <summary>
+    /// Extends the Generic <see cref="List{T}"/> class with an event that will fire when the list is updated.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class ListWithEvents<T> : List<T>
+    {
+        #region < Constructors >
+
+        ///<inheritdoc cref="List{T}()"/>
+        public ListWithEvents() : base() { }
+
+        ///<inheritdoc cref="List{T}(int)"/>
+        public ListWithEvents(int capacity) : base(capacity) { }
+
+        ///<inheritdoc cref="List{T}(IEnumerable{T})"/>
+        public ListWithEvents(IEnumerable<T> collection) : base(collection) { }
+
+        #endregion
+
+        #region < Properties >
+
+        #endregion
+
+        #region < Events >
+
+        /// <summary>
+        /// Event Args for the <see cref="ListWithEvents{T}.ListModification"/> event. <br/>
+        /// Reports what items have been added / removed from the list.
+        /// </summary>
+        public class ListModificationEventArgs : EventArgs
+        {
+            /// <summary>Create new instance of <see cref="ListModificationEventArgs"/></summary>
+            /// <param name="Item">Single Item Added/Removed from the list</param>
+            /// <param name="Added">
+            /// TRUE: Item(s) added to the <see cref="ItemsAdded"/> property. <br/>
+            /// FALSE: Item(s) added to the <see cref="ItemsRemoved"/> property. <br/>
+            /// </param>
+            public ListModificationEventArgs(T Item, bool Added) 
+            { 
+                this.ItemsAdded = Added ? new T[] { Item } : new T[] { };
+                this.ItemsRemoved = !Added ? new T[] { Item } : new T[] { };
+            }
+
+#pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do) -> Inherits the parameter description, but VS isn't smart enough to see it
+            /// <param name="collection">Collection of items added / removed from the list.</param>
+            /// <inheritdoc cref="ListModificationEventArgs.ListModificationEventArgs(T, bool)"/>            
+            public ListModificationEventArgs(IEnumerable<T> collection, bool Added)
+            { 
+                this.ItemsAdded = Added ? collection.ToArray() : new T[] { };
+                this.ItemsRemoved = !Added ? collection.ToArray() : new T[] { };
+            }
+#pragma warning restore CS1573
+
+            /// <summary> Array of items that were added to the list. </summary>
+            public T[] ItemsAdded { get; private set; }
+
+            /// <summary> Array of items that were removed from the list. </summary>
+            public T[] ItemsRemoved { get; private set; }
+        }
+
+        /// <summary>
+        /// Raise the <see cref="ListModification"/> event. <para/>
+        /// Override this method to provide post-processing of Added/Removed items within derived classes. <br/>
+        /// <see cref="HasEventListener_ListModification"/> may need to be overridden to allow post-processing.
+        /// </summary>
+        /// <param name="e"></param>
+        protected virtual void OnListModification(ListModificationEventArgs e) => ListModification?.Invoke(this, e);
+
+        /// <summary>
+        /// Boolean check that optimizes the Remove*/Clear methods if the ListModification Event has no listeners. (No need to collect information on removed items if not reacting to the event)
+        /// <para/>Override this method if you always wish to grab the removed items for processing during <see cref="OnListModification(ListModificationEventArgs)"/>
+        /// </summary>
+        /// <returns>Result of: ( <see cref="ListModification"/> != null ) </returns>
+        protected virtual bool HasEventListener_ListModification() { return ListModification != null; }
+
+        /// <summary> 
+        /// This event fires whenever the List's array is updated. 
+        /// <br/> The event will not fire when a new list is constructed/initialized, only when items are added or removed.
+        /// </summary>
+        public event EventHandler<ListModificationEventArgs> ListModification;
+
+        #endregion
+
+        #region < Methods that Override List<T> Methods >
+
+        ///<inheritdoc cref="List{T}.Insert(int, T)"/>
+        new public void Insert(int index, T item)
+        {
+            base.Insert(index, item);
+            OnListModification(new ListModificationEventArgs(item, true));
+        }
+
+        ///<inheritdoc cref="List{T}.Add(T)"/>
+        new public void Add(T item)
+        {
+            base.Add(item);
+            OnListModification(new ListModificationEventArgs(item, true));
+        }
+
+        ///<inheritdoc cref="System.Collections.Generic.List{T}.AddRange(IEnumerable{T})"/>
+        new public void AddRange(IEnumerable<T> collection)
+        {
+            base.AddRange(collection);
+            OnListModification(new ListModificationEventArgs(collection, true));
+        }
+
+        ///<inheritdoc cref="List{T}.Clear"/>
+        new public void Clear()
+        {
+            T[] arglist = HasEventListener_ListModification() ? base.ToArray() : null;
+            base.Clear();
+            OnListModification(new ListModificationEventArgs(arglist, false));
+        }
+
+        ///<inheritdoc cref="List{T}.Remove(T)"/>
+        new public bool Remove(T item)
+        {
+            if (base.Remove(item))
+            {
+                OnListModification(new ListModificationEventArgs(item, false));
+                return true;
+            }
+            else
+                return false;
+        }
+
+        ///<inheritdoc cref="List{T}.RemoveAt(int)"/>
+        new public void RemoveAt(int index)
+        {
+            T item = HasEventListener_ListModification() ? base[index] : default;
+            base.RemoveAt(index);
+            OnListModification(new ListModificationEventArgs(item, false));
+        }
+
+        ///<inheritdoc cref="List{T}.RemoveRange(int,int)"/>
+        new public void RemoveRange(int index, int count)
+        {
+            List<T> arglist = HasEventListener_ListModification() ? base.GetRange(index, count) : null;
+            base.RemoveRange(index, count);
+            OnListModification(new ListModificationEventArgs(arglist, false));
+        }
+
+        #endregion
+    }
+}

--- a/RoboSharp/GenericListWithEvents.cs
+++ b/RoboSharp/GenericListWithEvents.cs
@@ -5,9 +5,14 @@ using System.Collections.Specialized;
 namespace System.Collections.Generic
 {
     /// <summary>
-    /// Extends the Generic <see cref="List{T}"/> class with an event that will fire when the list is updated.
+    /// Extends the Generic <see cref="List{T}"/> class with an event that will fire when the list is updated. <para/>
+    /// Note: Replacing an item using  <c>List[index]={T}</c> will not trigger the <see cref="INotifyCollectionChanged"/> event. Use the { Replace } methods instead to trigger the event.
     /// </summary>
     /// <typeparam name="T"></typeparam>
+    /// <remarks>
+    /// This class is being provided by the RoboSharp DLL <br/>
+    /// <see href="https://github.com/tjscience/RoboSharp/tree/dev/RoboSharp/GenericListWithEvents.cs"/>
+    /// </remarks>
     public class ObservableList<T> : List<T>, INotifyCollectionChanged
     {
         #region < Constructors >
@@ -49,31 +54,93 @@ namespace System.Collections.Generic
 
         #endregion
 
+        #region < New Methods >
+
+        /// <summary>
+        /// Replace an item in the list and trigger a <see cref="INotifyCollectionChanged"/> event.
+        /// </summary>
+        /// <param name="itemToReplace">Search for this item in the list. If found, replace it.</param>
+        /// <param name="newItem">This item will replace the <paramref name="itemToReplace"/>. If <paramref name="itemToReplace"/> was not found, this item does not get added to the list.</param>
+        /// <returns>True if the <paramref name="itemToReplace"/> was found in the list and successfully replaced. Otherwise false.</returns>
+        public virtual bool Replace(T itemToReplace, T newItem)
+        {
+            if (!this.Contains(itemToReplace)) return false;
+            return Replace(this.IndexOf(itemToReplace), newItem);
+        }
+
+
+        /// <summary>
+        /// Replace an item in the list and trigger a <see cref="INotifyCollectionChanged"/> event. <br/>
+        /// </summary>
+        /// <param name="index">Index of the item to replace</param>
+        /// <param name="newItem">This item will replace the item at the specified <paramref name="index"/></param>
+        /// <returns>True if the the item was successfully replaced. Otherwise will throw due to IndexOutOfRange.</returns>
+        /// <exception cref="IndexOutOfRangeException"/>
+        public virtual bool Replace(int index, T newItem)
+        {
+            T oldItem = this[index];
+            this[index] = newItem;
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, newItems: new List<T> { newItem }, oldItems: new List<T> { oldItem }));
+            return true;
+        }
+
+        /// <summary>
+        /// Replaces the items in this list with the items in supplied collection. If the collection has more items than will be removed from the list, the remaining items will be added to the list. <br/>
+        /// EX: List has 10 items, collection has 5 items, index of 8 is specified (which is item 9 on 0-based index) -> Item 9 + 10 are replaced, and remaining 3 items from collection are added to the list.
+        /// </summary>
+        /// <param name="index">Index of the item to replace</param>
+        /// <param name="collection">Collection of items to insert into the list.</param>
+        /// <returns>True if the the collection was successfully inserted into the list. Otherwise throws.</returns>
+        /// <exception cref="IndexOutOfRangeException"/>
+        /// <exception cref="ArgumentException"/>
+        /// <exception cref="ArgumentNullException"/>
+        public virtual bool Replace(int index, IEnumerable<T> collection)
+        {
+            int collectionCount = collection.Count();
+            int ItemsAfterIndex = this.Count - index;     // # of items in the list after the index
+            int CountToReplace = collectionCount >= ItemsAfterIndex ? ItemsAfterIndex : ItemsAfterIndex - collectionCount;  //# if items that will be replaced
+            int AdditionalItems = collectionCount - CountToReplace; //# of additional items that will be added to the list.
+
+            List<T> oldItemsList = this.GetRange(index, CountToReplace);
+
+            //Insert the collection
+            base.RemoveRange(index, CountToReplace);
+            if (AdditionalItems > 0)
+                base.AddRange(collection);
+            else
+                base.InsertRange(index, collection);
+            
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, newItems: collection.ToList(), oldItems: oldItemsList, index));
+            return true;
+        }
+
+        #endregion
+
         #region < Methods that Override List<T> Methods >
 
         ///<inheritdoc cref="List{T}.Insert(int, T)"/>
-        new public void Insert(int index, T item)
+        new public virtual void Insert(int index, T item)
         {
             base.Insert(index, item);
             OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, index: index));
         }
 
         ///<inheritdoc cref="List{T}.Add(T)"/>
-        new public void Add(T item)
+        new public virtual void Add(T item)
         {
             base.Add(item);
             OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item));
         }
 
         ///<inheritdoc cref="System.Collections.Generic.List{T}.AddRange(IEnumerable{T})"/>
-        new public void AddRange(IEnumerable<T> collection)
+        new public virtual void AddRange(IEnumerable<T> collection)
         {
             base.AddRange(collection);
             OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, collection.ToList()));
         }
 
         ///<inheritdoc cref="List{T}.Clear"/>
-        new public void Clear()
+        new public virtual void Clear()
         {
             T[] removedItems = HasEventListener_CollectionChanged() ? base.ToArray() : null;
             base.Clear();
@@ -81,7 +148,7 @@ namespace System.Collections.Generic
         }
 
         ///<inheritdoc cref="List{T}.Remove(T)"/>
-        new public bool Remove(T item)
+        new public virtual bool Remove(T item)
         {
             if (base.Remove(item))
             {
@@ -93,7 +160,7 @@ namespace System.Collections.Generic
         }
 
         ///<inheritdoc cref="List{T}.RemoveAt(int)"/>
-        new public void RemoveAt(int index)
+        new public virtual void RemoveAt(int index)
         {
             T item = HasEventListener_CollectionChanged() ? base[index] : default;
             base.RemoveAt(index);
@@ -101,11 +168,67 @@ namespace System.Collections.Generic
         }
 
         ///<inheritdoc cref="List{T}.RemoveRange(int,int)"/>
-        new public void RemoveRange(int index, int count)
+        new public virtual void RemoveRange(int index, int count)
         {
             List<T> removedItems = HasEventListener_CollectionChanged() ? base.GetRange(index, count) : null;
             base.RemoveRange(index, count);
             OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset, newItems: new List<T>(), oldItems: removedItems.ToList()));
+        }
+
+        /// <remarks> Triggers a single <see cref="NotifyCollectionChangedAction.Move"/> event with no other parameters.</remarks>
+        ///<inheritdoc cref="List{T}.Reverse()"/>
+        new public virtual void Reverse()
+        {
+            base.Reverse();
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Move));
+        }
+
+        /// <remarks> Triggers a single <see cref="NotifyCollectionChangedAction.Move"/> event. EventArgs will report the original order of the items in the list. </remarks>
+        ///<inheritdoc cref="List{T}.Reverse(int, int)"/>
+        new public virtual void Reverse(int index, int count)
+        {
+            List<T> OriginalOrder = HasEventListener_CollectionChanged() ? base.GetRange(index, count) : null;
+            base.Reverse(index, count);
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Move, changedItem: OriginalOrder, index));
+
+            //Move Event for every moved object
+            //foreach ( T obj in OriginalOrder)
+            //{
+            //    int newIndex = this.IndexOf(obj);
+            //    int oldIndex = index + OriginalOrder.IndexOf(obj);
+            //    OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Move, obj, newIndex, oldIndex));
+            //}
+
+        }
+
+        ///<inheritdoc cref="List{T}.Sort()"/>
+        new public virtual void Sort()
+        {
+            base.Sort();
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Move));
+        }
+
+        ///<inheritdoc cref="List{T}.Sort(Comparison{T})"/>
+        new public virtual void Sort(Comparison<T> comparison)
+        {
+            base.Sort(comparison);
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Move));
+        }
+
+        ///<inheritdoc cref="List{T}.Sort(IComparer{T})"/>
+        new public virtual void Sort(IComparer<T> comparer)
+        {
+            base.Sort(comparer);
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Move));
+        }
+
+        /// <remarks> Triggers a single <see cref="NotifyCollectionChangedAction.Move"/> event. EventArgs will report the original order of the items in the list. </remarks>
+        ///<inheritdoc cref="List{T}.Sort(int, int, IComparer{T})"/>
+        new public virtual void Sort(int index, int count, IComparer<T> comparer)
+        {
+            List<T> OriginalOrder = HasEventListener_CollectionChanged() ? base.GetRange(index, count) : null;
+            base.Sort(index, count, comparer);
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Move, changedItems: OriginalOrder, index));
         }
 
         #endregion

--- a/RoboSharp/Results/ResultsBuilder.cs
+++ b/RoboSharp/Results/ResultsBuilder.cs
@@ -10,7 +10,17 @@ namespace RoboSharp.Results
     /// </summary>
     internal class ResultsBuilder
     {
+         
         private readonly List<string> outputLines = new List<string>();
+        
+        /// <see cref="RoboCommand.CommandOptions"/>
+        internal string CommandOptions { get; set; }
+
+        /// <inheritdoc cref="CopyOptions.Source"/>
+        internal string Source { get; set; }
+        
+        /// <inheritdoc cref="CopyOptions.Destination"/>
+        internal string Destination { get; set; }
 
         internal void AddOutput(string output)
         {
@@ -44,6 +54,9 @@ namespace RoboSharp.Results
 
             res.LogLines = outputLines.ToArray();
 
+            res.Source = this.Source;
+            res.Destination = this.Destination;
+            res.CommandOptions = this.CommandOptions;
             return res;
         }
 

--- a/RoboSharp/Results/RoboCopyExitCodes.cs
+++ b/RoboSharp/Results/RoboCopyExitCodes.cs
@@ -34,5 +34,7 @@ namespace RoboSharp.Results
         /// Either a usage error or an error due to insufficient access privileges on the source or destination directorie
         /// </summary>
         SeriousErrorOccoured = 0x10,
+        /// <summary>The Robocopy process exited prior to completion</summary>
+        Cancelled = -1,
     }
 }

--- a/RoboSharp/Results/RoboCopyResults.cs
+++ b/RoboSharp/Results/RoboCopyResults.cs
@@ -7,6 +7,12 @@ namespace RoboSharp.Results
     /// </summary>
     public class RoboCopyResults
     {
+        /// <inheritdoc cref="CopyOptions.Source"/>
+        public string Source { get; internal set; }
+        /// <inheritdoc cref="CopyOptions.Destination"/>
+        public string Destination { get; internal set; }
+        /// <inheritdoc cref="RoboCommand.CommandOptions"/>
+        public string CommandOptions { get; internal set; }
         /// <inheritdoc cref="RoboCopyExitStatus"/>
         public RoboCopyExitStatus Status { get; internal set; }
         /// <summary> Information about number of Directories Copied, Skipped, Failed, etc.</summary>

--- a/RoboSharp/Results/RoboCopyResultsList.cs
+++ b/RoboSharp/Results/RoboCopyResultsList.cs
@@ -80,19 +80,19 @@ namespace RoboSharp.Results
         #region < Public Properties >
 
         /// <summary> Sum of all DirectoryStatistics objects </summary>
-        public Statistic Total_DirectoriesStatistic => Total_DirStatsField.Value;
+        public Statistic DirectoriesStatistic => Total_DirStatsField.Value;
 
         /// <summary> Sum of all ByteStatistics objects </summary>
-        public Statistic Total_BytesStatistic => Total_ByteStatsField.Value;
+        public Statistic BytesStatistic => Total_ByteStatsField.Value;
 
         /// <summary> Sum of all FileStatistics objects </summary>
-        public Statistic Total_FilesStatistic => Total_FileStatsField.Value;
+        public Statistic FilesStatistic => Total_FileStatsField.Value;
 
         /// <summary> Average of all SpeedStatistics objects </summary>
-        public SpeedStatistic Average_SpeedStatistic => Average_SpeedStatsField.Value;
+        public SpeedStatistic SpeedStatistic => Average_SpeedStatsField.Value;
 
         /// <summary> Sum of all RoboCopyExitStatus objects </summary>
-        public RoboCopyExitStatus ExitStatusSummary => ExitStatusSummaryField.Value;
+        public RoboCopyExitStatus Status => ExitStatusSummaryField.Value;
 
         #endregion
 

--- a/RoboSharp/Results/RoboCopyResultsList.cs
+++ b/RoboSharp/Results/RoboCopyResultsList.cs
@@ -173,22 +173,27 @@ namespace RoboSharp.Results
         protected override void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
         {
             //Process New Items
-            int i = 0;
-            int i2 = e.NewItems.Count;
-            foreach (RoboCopyResults r in e.NewItems)
+            if (e.NewItems != null)
             {
-                i++;
-                AddItem(r, i == i2);
+                int i = 0;
+                int i2 = e.NewItems.Count;
+                foreach (RoboCopyResults r in e?.NewItems)
+                {
+                    i++;
+                    AddItem(r, i == i2);
+                }
             }
             //Process Removed Items
-            i = 0;
-            i2 = e.OldItems.Count;
-            foreach (RoboCopyResults r in e.OldItems)
+            if (e.OldItems != null)
             {
-                i++;
-                SubtractItem(r, i == i2);
+                int i = 0;
+                int i2 = e.OldItems.Count;
+                foreach (RoboCopyResults r in e?.OldItems)
+                {
+                    i++;
+                    SubtractItem(r, i == i2);
+                }
             }
-
             //Raise the event
             base.OnCollectionChanged(e);
         }

--- a/RoboSharp/Results/RoboCopyResultsList.cs
+++ b/RoboSharp/Results/RoboCopyResultsList.cs
@@ -1,0 +1,254 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace RoboSharp.Results
+{
+    /// <summary>
+    /// Object used to represent reults from multiple <see cref="RoboCommand"/>s. <br/>
+    /// As <see cref="RoboCopyResults"/> are added to this object, it will update the Totals and Averages accordingly.
+    /// </summary>
+    /// <remarks>
+    /// This object is derived from <see cref="List{T}"/>, where T = <see cref="RoboCopyResults"/>.
+    /// </remarks>
+    public sealed class RoboCopyResultsList : ListWithEvents<RoboCopyResults>
+    {
+        #region < Constructors >
+
+        /// <inheritdoc cref="List{T}.List()"/>
+        public RoboCopyResultsList() : base() { Init(); }
+
+        /// <param name="result">Populate the new List object with this result as the first item.</param>
+        /// <inheritdoc cref="List{T}.List(IEnumerable{T})"/>
+        public RoboCopyResultsList(RoboCopyResults result) :base(collection: new RoboCopyResults[] { result } ) { Init(); }
+
+        /// <inheritdoc cref="List{T}.List(int)"/>
+        public RoboCopyResultsList(int capacity): base(capacity: capacity) { Init(); }
+
+        /// <inheritdoc cref="List{T}.List(IEnumerable{T})"/>
+        public RoboCopyResultsList(List<RoboCopyResults> collection) : base(collection) { Init(); }
+
+        /// <inheritdoc cref="List{T}.List(IEnumerable{T})"/>
+        public RoboCopyResultsList(IEnumerable<RoboCopyResults> collection) :base(collection) { Init(); }
+
+        private void Init() 
+        {
+            Total_DirStatsField = new Lazy<Statistic>(() => Statistic.AddStatistics(this.GetDirectoriesStatistics()));
+            Total_ByteStatsField = new Lazy<Statistic>(() => Statistic.AddStatistics(this.GetByteStatistics()));
+            Total_FileStatsField = new Lazy<Statistic>(() => Statistic.AddStatistics(this.GetFilesStatistics()));
+            Average_SpeedStatsField = new Lazy<SpeedStatistic>(
+                () =>
+                {
+                    if (this.Count == 0)
+                    {
+                        this.SpeedStatValid = false;
+                        return new SpeedStatistic();
+                    }
+                    else
+                    {
+                        this.SpeedStatValid = true;
+                        return SpeedStatistic.AverageStatistics(this.GetSpeedStatistics());
+                    }
+                });
+        }
+
+        #endregion
+
+        #region < Fields >
+
+        //These objects are the underlying Objects that may be bound to by consumers.
+        //The values are updated upon request of the associated property. 
+        //This is so that properties are not returning new objects every request (which would break bindings)
+        //If the statistic is never requested, then Lazy<> allows the list to skip performing the math against that statistic.
+
+        private Lazy<Statistic> Total_DirStatsField;
+        private Lazy<Statistic> Total_ByteStatsField;
+        private Lazy<Statistic> Total_FileStatsField;
+        private Lazy<SpeedStatistic> Average_SpeedStatsField;
+        
+        /// <summary> 
+        /// Speed Stat can be averaged only if the first value was supplied by an actual result. <br/> 
+        /// Set TRUE after first item was added to the list, set FALSE if list is cleared.
+        /// </summary>
+        private bool SpeedStatValid { get; set; }
+
+        #endregion
+
+        #region < Public Properties >
+
+        /// <summary> Sum of all DirectoryStatistics objects </summary>
+        public Statistic Total_DirectoriesStatistic => Total_DirStatsField.Value;
+
+        /// <summary> Sum of all ByteStatistics objects </summary>
+        public Statistic Total_BytesStatistic => Total_ByteStatsField.Value;
+
+        /// <summary> Sum of all FileStatistics objects </summary>
+        public Statistic Total_FilesStatistic => Total_FileStatsField.Value;
+
+        /// <summary> Average of all SpeedStatistics objects </summary>
+        public SpeedStatistic Average_SpeedStatistic => Average_SpeedStatsField.Value;
+
+        #endregion
+
+        #region < Get Array Methods >
+
+        /// <summary>
+        /// Get a snapshot of the ByteStatistics objects from this list.
+        /// </summary>
+        /// <returns>New array of the ByteStatistic objects</returns>
+        public Statistic[] GetByteStatistics()
+        {
+            List<Statistic> tmp = new List<Statistic>{ };
+            foreach (RoboCopyResults r in this)
+                tmp.Add(r?.BytesStatistic);
+            return tmp.ToArray();
+        }
+
+        /// <summary>
+        /// Get a snapshot of the DirectoriesStatistic objects from this list.
+        /// </summary>
+        /// <returns>New array of the DirectoriesStatistic objects</returns>
+        public Statistic[] GetDirectoriesStatistics()
+        {
+            List<Statistic> tmp = new List<Statistic> { };
+            foreach (RoboCopyResults r in this)
+                tmp.Add(r?.DirectoriesStatistic);
+            return tmp.ToArray();
+        }
+
+        /// <summary>
+        /// Get a snapshot of the FilesStatistic objects from this list.
+        /// </summary>
+        /// <returns>New array of the FilesStatistic objects</returns>
+        public Statistic[] GetFilesStatistics()
+        {
+            List<Statistic> tmp = new List<Statistic> { };
+            foreach (RoboCopyResults r in this)
+                tmp.Add(r?.FilesStatistic);
+            return tmp.ToArray();
+        }
+
+        /// <summary>
+        /// Get a snapshot of the FilesStatistic objects from this list.
+        /// </summary>
+        /// <returns>New array of the FilesStatistic objects</returns>
+        public RoboCopyExitStatus[] GetStatuses()
+        {
+            List<RoboCopyExitStatus> tmp = new List<RoboCopyExitStatus> { };
+            foreach (RoboCopyResults r in this)
+                tmp.Add(r?.Status);
+            return tmp.ToArray();
+        }
+
+        /// <summary>
+        /// Get a snapshot of the FilesStatistic objects from this list.
+        /// </summary>
+        /// <returns>New array of the FilesStatistic objects</returns>
+        public SpeedStatistic[] GetSpeedStatistics()
+        {
+            List<SpeedStatistic> tmp = new List<SpeedStatistic> { };
+            foreach (RoboCopyResults r in this)
+                tmp.Add(r?.SpeedStatistic);
+            return tmp.ToArray();
+        }
+
+        #endregion
+
+        #region < Methods that handle List Modifications >
+
+        /// <summary>Overrides the Event Listener check since this class always processes added/removed items.</summary>
+        /// <returns>True</returns>
+        protected override bool HasEventListener_ListModification() => true;
+
+        /// <summary>Process the Added/Removed items, then fire the event</summary>
+        /// <inheritdoc cref="ListWithEvents{T}.OnListModification(ListWithEvents{T}.ListModificationEventArgs)"/>
+        protected override void OnListModification(ListModificationEventArgs e)
+        {
+            foreach (RoboCopyResults r in e.ItemsAdded)
+                AddItem(r, e.ItemsAdded.Last() == r);
+            foreach (RoboCopyResults r in e.ItemsRemoved)
+                SubtractItem(r, e.ItemsRemoved.Last() == r);
+            base.OnListModification(e);
+        }
+
+        /// <summary>
+        /// Adds item to the private Statistics objects
+        /// </summary>
+        /// <param name="item"></param>
+        /// <param name="RaiseValueChangeEvent"><inheritdoc cref="Statistic.EnablePropertyChangeEvent" path="*"/></param>
+        private void AddItem(RoboCopyResults item, bool RaiseValueChangeEvent)
+        {
+            //Bytes
+            if (Total_ByteStatsField.IsValueCreated)
+                Total_ByteStatsField.Value.AddStatistic(item?.BytesStatistic, RaiseValueChangeEvent);
+            //Directories
+            if (Total_DirStatsField.IsValueCreated)
+                Total_DirStatsField.Value.AddStatistic(item?.DirectoriesStatistic, RaiseValueChangeEvent);
+            //Files
+            if (Total_FileStatsField.IsValueCreated)
+                Total_FileStatsField.Value.AddStatistic(item?.FilesStatistic, RaiseValueChangeEvent);
+            //Speed
+            if (Average_SpeedStatsField.IsValueCreated)
+            {
+                if (SpeedStatValid)
+                    //Average the new value with the previous average
+                    Average_SpeedStatsField.Value.AverageStatistic(item?.SpeedStatistic);
+                else
+                {
+                    //The previous value was not valid since it was not based off a RoboCopy Result. 
+                    //Set the value starting average to this item's value.
+                    Average_SpeedStatsField.Value.SetValues(item?.SpeedStatistic);
+                    SpeedStatValid = item?.SpeedStatistic != null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Subtracts item from the private Statistics objects
+        /// </summary>
+        /// <param name="item"></param>
+        /// <param name="ReCalculateSpeedNow">Triggers Recalculating the Average Speed Stats if needed.<para/><inheritdoc cref="Statistic.EnablePropertyChangeEvent" path="*"/></param>
+        private void SubtractItem(RoboCopyResults item, bool ReCalculateSpeedNow)
+        {
+            //Bytes
+            if (Total_ByteStatsField.IsValueCreated)
+                Total_ByteStatsField.Value.Subtract(item?.BytesStatistic, ReCalculateSpeedNow);
+            //Directories
+            if (Total_DirStatsField.IsValueCreated)
+                Total_DirStatsField.Value.Subtract(item?.DirectoriesStatistic, ReCalculateSpeedNow);
+            //Files
+            if (Total_FileStatsField.IsValueCreated)
+                Total_FileStatsField.Value.Subtract(item?.FilesStatistic, ReCalculateSpeedNow);
+            //Speed
+            if (Average_SpeedStatsField.IsValueCreated && ReCalculateSpeedNow)
+            {
+                if (this.Count == 0)
+                {
+                    Average_SpeedStatsField.Value.Reset();
+                    SpeedStatValid = false;
+                }
+                if (this.Count == 1)
+                {
+                    Average_SpeedStatsField.Value.SetValues(item?.SpeedStatistic);
+                    SpeedStatValid = true;
+                }
+                else
+                {
+                    List<SpeedStatistic> tmpList = new List<SpeedStatistic>();
+                    foreach (RoboCopyResults r in this)
+                        tmpList.Add(r?.SpeedStatistic);
+                    SpeedStatistic tmp = SpeedStatistic.AverageStatistics(tmpList);
+                    Average_SpeedStatsField.Value.SetValues(tmp);
+                    SpeedStatValid = true;
+                }
+            }
+        }
+
+
+
+        #endregion
+
+    }
+}
+

--- a/RoboSharp/Results/RoboCopyResultsList.cs
+++ b/RoboSharp/Results/RoboCopyResultsList.cs
@@ -32,7 +32,7 @@ namespace RoboSharp.Results
         /// <inheritdoc cref="List{T}.List(IEnumerable{T})"/>
         public RoboCopyResultsList(IEnumerable<RoboCopyResults> collection) :base(collection) { Init(); }
 
-        private void Init() 
+        private void Init()
         {
             Total_DirStatsField = new Lazy<Statistic>(() => Statistic.AddStatistics(this.GetDirectoriesStatistics()));
             Total_ByteStatsField = new Lazy<Statistic>(() => Statistic.AddStatistics(this.GetByteStatistics()));
@@ -51,6 +51,7 @@ namespace RoboSharp.Results
                         return SpeedStatistic.AverageStatistics(this.GetSpeedStatistics());
                     }
                 });
+            ExitStatusSummaryField = new Lazy<RoboCopyExitStatus>(() => RoboCopyExitStatus.CombineStatuses(this.GetStatuses()));
         }
 
         #endregion
@@ -66,7 +67,8 @@ namespace RoboSharp.Results
         private Lazy<Statistic> Total_ByteStatsField;
         private Lazy<Statistic> Total_FileStatsField;
         private Lazy<SpeedStatistic> Average_SpeedStatsField;
-        
+        private Lazy<RoboCopyExitStatus> ExitStatusSummaryField;
+
         /// <summary> 
         /// Speed Stat can be averaged only if the first value was supplied by an actual result. <br/> 
         /// Set TRUE after first item was added to the list, set FALSE if list is cleared.
@@ -88,6 +90,9 @@ namespace RoboSharp.Results
 
         /// <summary> Average of all SpeedStatistics objects </summary>
         public SpeedStatistic Average_SpeedStatistic => Average_SpeedStatsField.Value;
+
+        /// <summary> Sum of all RoboCopyExitStatus objects </summary>
+        public RoboCopyExitStatus ExitStatusSummary => ExitStatusSummaryField.Value;
 
         #endregion
 
@@ -188,6 +193,10 @@ namespace RoboSharp.Results
             //Files
             if (Total_FileStatsField.IsValueCreated)
                 Total_FileStatsField.Value.AddStatistic(item?.FilesStatistic, RaiseValueChangeEvent);
+            //Exit Status
+            if (ExitStatusSummaryField.IsValueCreated)
+                ExitStatusSummaryField.Value.CombineStatus(item?.Status);
+            
             //Speed
             if (Average_SpeedStatsField.IsValueCreated)
             {

--- a/RoboSharp/Results/RoboCopyResultsList.cs
+++ b/RoboSharp/Results/RoboCopyResultsList.cs
@@ -252,7 +252,7 @@ namespace RoboSharp.Results
                     //Exit Status
                     if (ExitStatusSummaryField.IsValueCreated && RaiseValueChangeEvent)
                     {
-                        ExitStatusSummaryField.Value.Reset();
+                        ExitStatusSummaryField.Value.Reset(false);
                         ExitStatusSummaryField.Value.CombineStatus(GetStatuses());
                     }
                     //Speed

--- a/RoboSharp/Results/RoboCopyResultsList.cs
+++ b/RoboSharp/Results/RoboCopyResultsList.cs
@@ -177,6 +177,7 @@ namespace RoboSharp.Results
                     //Speed
                     if (Average_SpeedStatsField.IsValueCreated)
                         Average_SpeedStatsField.Value.Add(r?.SpeedStatistic);
+                    if (RaiseValueChangeEvent) Average_SpeedStatsField.Value.CalculateAverage();
                 }
             }
 
@@ -185,10 +186,10 @@ namespace RoboSharp.Results
             {
                 int i = 0;
                 int i2 = e.OldItems.Count;
-                bool RaiseValueChangeEvent = i == i2;
                 foreach (RoboCopyResults r in e?.OldItems)
                 {
                     i++;
+                    bool RaiseValueChangeEvent = i == i2;
                     //Bytes
                     if (Total_ByteStatsField.IsValueCreated)
                         Total_ByteStatsField.Value.Subtract(r?.BytesStatistic, RaiseValueChangeEvent);
@@ -211,7 +212,6 @@ namespace RoboSharp.Results
                             Average_SpeedStatsField.Value.Reset();
                         else
                             Average_SpeedStatsField.Value.Subtract(r.SpeedStatistic);
-
                         if (RaiseValueChangeEvent) Average_SpeedStatsField.Value.CalculateAverage();
                     }
                 }

--- a/RoboSharp/Results/RoboCopyResultsList.cs
+++ b/RoboSharp/Results/RoboCopyResultsList.cs
@@ -221,7 +221,7 @@ namespace RoboSharp.Results
                         Total_FileStatsField.Value.AddStatistic(r?.FilesStatistic, RaiseValueChangeEvent);
                     //Exit Status
                     if (ExitStatusSummaryField.IsValueCreated)
-                        ExitStatusSummaryField.Value.CombineStatus(r?.Status);
+                        ExitStatusSummaryField.Value.CombineStatus(r?.Status, RaiseValueChangeEvent);
                     //Speed
                     if (Average_SpeedStatsField.IsValueCreated)
                     {

--- a/RoboSharp/Results/RoboCopyResultsList.cs
+++ b/RoboSharp/Results/RoboCopyResultsList.cs
@@ -8,11 +8,11 @@ using System.Collections.Specialized;
 namespace RoboSharp.Results
 {
     /// <summary>
-    /// Object used to represent reults from multiple <see cref="RoboCommand"/>s. <br/>
+    /// Object used to represent results from multiple <see cref="RoboCommand"/>s. <br/>
     /// As <see cref="RoboCopyResults"/> are added to this object, it will update the Totals and Averages accordingly.
     /// </summary>
     /// <remarks>
-    /// This object is derived from <see cref="List{T}"/>, where T = <see cref="RoboCopyResults"/>.
+    /// This object is derived from <see cref="List{T}"/>, where T = <see cref="RoboCopyResults"/>, and implements <see cref="INotifyCollectionChanged"/>
     /// </remarks>
     public sealed class RoboCopyResultsList : ObservableList<RoboCopyResults>
     {

--- a/RoboSharp/Results/RoboCopyResultsList.cs
+++ b/RoboSharp/Results/RoboCopyResultsList.cs
@@ -14,7 +14,7 @@ namespace RoboSharp.Results
     /// <remarks>
     /// This object is derived from <see cref="List{T}"/>, where T = <see cref="RoboCopyResults"/>, and implements <see cref="INotifyCollectionChanged"/>
     /// </remarks>
-    public sealed class RoboCopyResultsList : ObservableList<RoboCopyResults>
+    public sealed class RoboCopyResultsList : ObservableList<RoboCopyResults>, IDisposable
     {
         #region < Constructors >
 
@@ -57,25 +57,28 @@ namespace RoboSharp.Results
         private Lazy<Statistic> Total_FileStatsField;
         private Lazy<AverageSpeedStatistic> Average_SpeedStatsField;
         private Lazy<RoboCopyCombinedExitStatus> ExitStatusSummaryField;
+        private bool disposedValue;
+        private bool startedDisposing;
+        private bool Disposed => disposedValue || startedDisposing;
 
         #endregion
 
         #region < Public Properties >
 
         /// <summary> Sum of all DirectoryStatistics objects </summary>
-        public Statistic DirectoriesStatistic => Total_DirStatsField.Value;
+        public Statistic DirectoriesStatistic => Total_DirStatsField?.Value;
 
         /// <summary> Sum of all ByteStatistics objects </summary>
-        public Statistic BytesStatistic => Total_ByteStatsField.Value;
+        public Statistic BytesStatistic => Total_ByteStatsField?.Value;
 
         /// <summary> Sum of all FileStatistics objects </summary>
-        public Statistic FilesStatistic => Total_FileStatsField.Value;
+        public Statistic FilesStatistic => Total_FileStatsField?.Value;
 
         /// <summary> Average of all SpeedStatistics objects </summary>
-        public SpeedStatistic SpeedStatistic => Average_SpeedStatsField.Value;
+        public SpeedStatistic SpeedStatistic => Average_SpeedStatsField?.Value;
 
         /// <summary> Sum of all RoboCopyExitStatus objects </summary>
-        public RoboCopyExitStatus Status => ExitStatusSummaryField.Value;
+        public RoboCopyExitStatus Status => ExitStatusSummaryField?.Value;
 
         #endregion
 
@@ -87,6 +90,7 @@ namespace RoboSharp.Results
         /// <returns>New array of the ByteStatistic objects</returns>
         public Statistic[] GetByteStatistics()
         {
+            if (Disposed) return null;
             List<Statistic> tmp = new List<Statistic>{ };
             foreach (RoboCopyResults r in this)
                 tmp.Add(r?.BytesStatistic);
@@ -99,6 +103,7 @@ namespace RoboSharp.Results
         /// <returns>New array of the DirectoriesStatistic objects</returns>
         public Statistic[] GetDirectoriesStatistics()
         {
+            if (Disposed) return null;
             List<Statistic> tmp = new List<Statistic> { };
             foreach (RoboCopyResults r in this)
                 tmp.Add(r?.DirectoriesStatistic);
@@ -111,6 +116,7 @@ namespace RoboSharp.Results
         /// <returns>New array of the FilesStatistic objects</returns>
         public Statistic[] GetFilesStatistics()
         {
+            if (Disposed) return null;
             List<Statistic> tmp = new List<Statistic> { };
             foreach (RoboCopyResults r in this)
                 tmp.Add(r?.FilesStatistic);
@@ -123,6 +129,7 @@ namespace RoboSharp.Results
         /// <returns>New array of the FilesStatistic objects</returns>
         public RoboCopyExitStatus[] GetStatuses()
         {
+            if (Disposed) return null;
             List<RoboCopyExitStatus> tmp = new List<RoboCopyExitStatus> { };
             foreach (RoboCopyResults r in this)
                 tmp.Add(r?.Status);
@@ -135,6 +142,7 @@ namespace RoboSharp.Results
         /// <returns>New array of the FilesStatistic objects</returns>
         public SpeedStatistic[] GetSpeedStatistics()
         {
+            if (Disposed) return null;
             List<SpeedStatistic> tmp = new List<SpeedStatistic> { };
             foreach (RoboCopyResults r in this)
                 tmp.Add(r?.SpeedStatistic);
@@ -153,6 +161,8 @@ namespace RoboSharp.Results
         /// <inheritdoc cref="ObservableList{T}.OnCollectionChanged(NotifyCollectionChangedEventArgs)"/>
         protected override void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
         {
+            if (Disposed) return;
+
             //Process New Items
             if (e.NewItems != null)
             {
@@ -219,6 +229,50 @@ namespace RoboSharp.Results
 
             //Raise the CollectionChanged event
             base.OnCollectionChanged(e);
+        }
+
+        #endregion
+
+        #region < IDisposable >
+
+        private void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                startedDisposing = true;
+
+                if (disposing)
+                {
+                    this.Clear();
+                    Total_ByteStatsField = null;
+                    Total_DirStatsField = null;
+                    Total_FileStatsField = null;
+                    Average_SpeedStatsField = null;
+                    ExitStatusSummaryField = null;
+                }
+
+                // TODO: free unmanaged resources (unmanaged objects) and override finalizer
+                // TODO: set large fields to null
+                disposedValue = true;
+            }
+        }
+
+        // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
+        // ~RoboCopyResultsList()
+        // {
+        //     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        //     Dispose(disposing: false);
+        // }
+
+        /// <summary>
+        /// Clear the list and Set all the calculated statistics objects to null <br/>
+        /// This object uses no 'Unmanaged' resources, so this is not strictly required to be called.
+        /// </summary>
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
 
         #endregion

--- a/RoboSharp/Results/RoboCopyResultsList.cs
+++ b/RoboSharp/Results/RoboCopyResultsList.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 
 namespace RoboSharp.Results
 {
@@ -12,7 +14,7 @@ namespace RoboSharp.Results
     /// <remarks>
     /// This object is derived from <see cref="List{T}"/>, where T = <see cref="RoboCopyResults"/>.
     /// </remarks>
-    public sealed class RoboCopyResultsList : ListWithEvents<RoboCopyResults>
+    public sealed class RoboCopyResultsList : ObservableList<RoboCopyResults>
     {
         #region < Constructors >
 
@@ -164,17 +166,31 @@ namespace RoboSharp.Results
 
         /// <summary>Overrides the Event Listener check since this class always processes added/removed items.</summary>
         /// <returns>True</returns>
-        protected override bool HasEventListener_ListModification() => true;
+        protected override bool HasEventListener_CollectionChanged() => true;
 
         /// <summary>Process the Added/Removed items, then fire the event</summary>
-        /// <inheritdoc cref="ListWithEvents{T}.OnListModification(ListWithEvents{T}.ListModificationEventArgs)"/>
-        protected override void OnListModification(ListModificationEventArgs e)
+        /// <inheritdoc cref="ObservableList{T}.OnCollectionChanged(NotifyCollectionChangedEventArgs)"/>
+        protected override void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
         {
-            foreach (RoboCopyResults r in e.ItemsAdded)
-                AddItem(r, e.ItemsAdded.Last() == r);
-            foreach (RoboCopyResults r in e.ItemsRemoved)
-                SubtractItem(r, e.ItemsRemoved.Last() == r);
-            base.OnListModification(e);
+            //Process New Items
+            int i = 0;
+            int i2 = e.NewItems.Count;
+            foreach (RoboCopyResults r in e.NewItems)
+            {
+                i++;
+                AddItem(r, i == i2);
+            }
+            //Process Removed Items
+            i = 0;
+            i2 = e.OldItems.Count;
+            foreach (RoboCopyResults r in e.OldItems)
+            {
+                i++;
+                SubtractItem(r, i == i2);
+            }
+
+            //Raise the event
+            base.OnCollectionChanged(e);
         }
 
         /// <summary>

--- a/RoboSharp/Results/RoboCopyResultsList.cs
+++ b/RoboSharp/Results/RoboCopyResultsList.cs
@@ -53,7 +53,7 @@ namespace RoboSharp.Results
                         return SpeedStatistic.AverageStatistics(this.GetSpeedStatistics());
                     }
                 });
-            ExitStatusSummaryField = new Lazy<RoboCopyExitStatus>(() => RoboCopyExitStatus.CombineStatuses(this.GetStatuses()));
+            ExitStatusSummaryField = new Lazy<RoboCopyCombinedExitStatus>(() => RoboCopyCombinedExitStatus.CombineStatuses(this.GetStatuses()));
         }
 
         #endregion
@@ -69,7 +69,7 @@ namespace RoboSharp.Results
         private Lazy<Statistic> Total_ByteStatsField;
         private Lazy<Statistic> Total_FileStatsField;
         private Lazy<SpeedStatistic> Average_SpeedStatsField;
-        private Lazy<RoboCopyExitStatus> ExitStatusSummaryField;
+        private Lazy<RoboCopyCombinedExitStatus> ExitStatusSummaryField;
 
         /// <summary> 
         /// Speed Stat can be averaged only if the first value was supplied by an actual result. <br/> 
@@ -250,6 +250,12 @@ namespace RoboSharp.Results
             //Files
             if (Total_FileStatsField.IsValueCreated)
                 Total_FileStatsField.Value.Subtract(item?.FilesStatistic, ReCalculateSpeedNow);
+            //Exit Status
+            if (ExitStatusSummaryField.IsValueCreated && ReCalculateSpeedNow)
+            {
+                ExitStatusSummaryField.Value.Reset();
+                ExitStatusSummaryField.Value.CombineStatus(GetStatuses());
+            }
             //Speed
             if (Average_SpeedStatsField.IsValueCreated && ReCalculateSpeedNow)
             {

--- a/RoboSharp/Results/RoboCopyResultsStatus.cs
+++ b/RoboSharp/Results/RoboCopyResultsStatus.cs
@@ -65,14 +65,14 @@ namespace RoboSharp.Results
             if (status == null) return;
             if (status.WasCancelled)
             {
-                this.wascancelled = true;
+                wascancelled = true;
             }
             else
             {
-                RoboCopyExitCodes code = this.ExitCode & status.ExitCode;
-                this.ExitCodeValue = (int)code;
+                RoboCopyExitCodes code = ExitCode | status.ExitCode;
+                ExitCodeValue = (int)code;
             }
-            this.IsCombinedStatus = true;
+            IsCombinedStatus = true;
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace RoboSharp.Results
         {
             foreach (RoboCopyExitStatus s in status)
             {
-                this.CombineStatus(s);
+                CombineStatus(s);
             }
         }
 

--- a/RoboSharp/Results/RoboCopyResultsStatus.cs
+++ b/RoboSharp/Results/RoboCopyResultsStatus.cs
@@ -1,4 +1,6 @@
-﻿namespace RoboSharp.Results
+﻿using System.Collections.Generic;
+
+namespace RoboSharp.Results
 {
     /// <summary>
     /// Object that evaluates the ExitCode reported after RoboCopy finishes executing.
@@ -11,22 +13,35 @@
         public RoboCopyExitStatus(int exitCodeValue)
         {
             ExitCodeValue = exitCodeValue;
+            IsCombinedStatus = false;
         }
 
         /// <summary>ExitCode as reported by RoboCopy</summary>
-        public int ExitCodeValue { get; }
+        public int ExitCodeValue { get; private set; }
 
         /// <summary>ExitCode reported by RoboCopy converted into the Enum</summary>
         public RoboCopyExitCodes ExitCode => (RoboCopyExitCodes)ExitCodeValue;
-        
+
         /// <inheritdoc cref="RoboCopyExitCodes.FilesCopiedSuccessful"/>
         public bool Successful => ExitCodeValue < 0x10;
 
         /// <inheritdoc cref="RoboCopyExitCodes.MismatchedDirectoriesDetected"/>
         public bool HasWarnings => ExitCodeValue >= 0x4;
-        
+
         /// <inheritdoc cref="RoboCopyExitCodes.SeriousErrorOccoured"/>
         public bool HasErrors => ExitCodeValue >= 0x10;
+
+        /// <inheritdoc cref="RoboCopyExitCodes.Cancelled"/>
+        public bool WasCancelled => wascancelled || ExitCodeValue < 0x0;
+
+        /// <summary> 
+        /// If this object is the result of two RoboCopyExitStatus objects being combined, this will be TRUE. <br/>
+        /// Otherwise this will be false. 
+        /// </summary>
+        public bool IsCombinedStatus { get; private set; }
+
+        /// <summary> This is purely to facilitate the CombineStatus method </summary>
+        private bool wascancelled;
 
         /// <summary>
         /// Returns a string that represents the current object.
@@ -35,5 +50,53 @@
         {
             return $"ExitCode: {ExitCodeValue} ({ExitCode})";
         }
+
+        /// <summary>
+        /// Combine the RoboCopyExitCodes of the supplied ExitStatus with this ExitStatus.
+        /// </summary>
+        /// <remarks>If any were Cancelled, set the WasCancelled property to TRUE. Otherwise combine the exit codes.</remarks>
+        /// <param name="status">ExitStatus to combine with</param>
+#if !NET40
+        [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
+#endif
+        public void CombineStatus(RoboCopyExitStatus status)
+        {
+            if (status == null) return;
+            if (status.WasCancelled)
+            {
+                this.wascancelled = true;
+            }
+            else
+            {
+                RoboCopyExitCodes code = this.ExitCode & status.ExitCode;
+                this.ExitCodeValue = (int)code;
+            }
+            this.IsCombinedStatus = true;
+        }
+
+        /// <summary>
+        /// Combine all the RoboCopyExitStatuses together.
+        /// </summary>
+        /// <param name="status">Array or List of ExitStatuses to combine.</param>
+        public void CombineStatus(IEnumerable<RoboCopyExitStatus> status)
+        {
+            foreach (RoboCopyExitStatus s in status)
+            {
+                this.CombineStatus(s);
+            }
+        }
+
+        /// <summary>
+        /// Combine all the RoboCopyExitStatuses together.
+        /// </summary>
+        /// <param name="statuses">Array or List of ExitStatuses to combine.</param>
+        /// <returns> new RoboCopyExitStatus object </returns>
+        public static RoboCopyExitStatus CombineStatuses(IEnumerable<RoboCopyExitStatus> statuses)
+        {
+            RoboCopyExitStatus ret = new RoboCopyExitStatus(0);
+            ret.CombineStatus(statuses);
+            return ret;
+        }
+
     }
 }

--- a/RoboSharp/Results/RoboCopyResultsStatus.cs
+++ b/RoboSharp/Results/RoboCopyResultsStatus.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace RoboSharp.Results
 {

--- a/RoboSharp/Results/SpeedStatistic.cs
+++ b/RoboSharp/Results/SpeedStatistic.cs
@@ -97,7 +97,7 @@ namespace RoboSharp.Results
     /// This object represents the Average of several <see cref="SpeedStatistic"/> objects, and contains 
     /// methods to facilitate that functionality.
     /// </summary>
-    public class AverageSpeedStatistic : SpeedStatistic
+    public sealed class AverageSpeedStatistic : SpeedStatistic
     {
         #region < Constructors >
 

--- a/RoboSharp/Results/SpeedStatistic.cs
+++ b/RoboSharp/Results/SpeedStatistic.cs
@@ -5,16 +5,54 @@ using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace RoboSharp.Results
 {
     /// <summary> Contains information regarding average Transfer Speed </summary>
-    public class SpeedStatistic
+    public class SpeedStatistic : INotifyPropertyChanged
     {
+        #region < Fields, Events, Properties >
+
+        private decimal BytesPerSecField;
+        private decimal MegaBytesPerMinField;
+
+        /// <summary> This toggle Enables/Disables firing the <see cref="PropertyChanged"/> Event to avoid firing it when doing multiple consecutive changes to the values </summary>
+        private bool EnablePropertyChangeEvent { get; set; } = true;
+
+        /// <summary>This event will fire when the value of the SpeedStatistic is updated </summary>
+        public event PropertyChangedEventHandler PropertyChanged;
+
         /// <summary> Average Transfer Rate in Bytes/Second </summary>
-        public decimal BytesPerSec { get; private set; }
+        public decimal BytesPerSec {
+            get => BytesPerSecField;
+            private set
+            {
+                if (BytesPerSecField != value)
+                {
+                    BytesPerSecField = value;
+                    if (EnablePropertyChangeEvent) PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("MegaBytesPerMin"));
+                }
+            }
+        }
+
         /// <summary> Average Transfer Rate in MB/Minute</summary>
-        public decimal MegaBytesPerMin { get; private set; }
+        public decimal MegaBytesPerMin {
+            get => MegaBytesPerMinField;
+            private set
+            {
+                if (MegaBytesPerMinField != value)
+                {
+                    MegaBytesPerMinField = value;
+                    if (EnablePropertyChangeEvent) PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("MegaBytesPerMin"));
+                }
+            }
+        }
+
+        #endregion
+
+        #region < Methods >
 
         /// <summary>
         /// Returns a string that represents the current object.
@@ -46,6 +84,52 @@ namespace RoboSharp.Results
             return res;
         }
 
+        #endregion
+
+        #region < Set Value Methods >
+
+        /// <summary>
+        /// Set the values for this object to 0
+        /// </summary>
+        public void Reset()
+        {
+            BytesPerSec = 0;
+            MegaBytesPerMin = 0;
+        }
+
+        /// <summary>
+        /// Set the values for this object to 0
+        /// </summary>
+        internal void Reset(bool enablePropertyChangeEvent)
+        {
+            EnablePropertyChangeEvent = enablePropertyChangeEvent;
+            BytesPerSec = 0;
+            MegaBytesPerMin = 0;
+            EnablePropertyChangeEvent = true;
+        }
+
+        /// <inheritdoc cref="SetValues(SpeedStatistic, bool)"/>
+        public void SetValues(SpeedStatistic speedStat) 
+        {
+            MegaBytesPerMin = speedStat?.MegaBytesPerMin ?? 0;
+            BytesPerSec = speedStat?.BytesPerSec ?? 0;
+        }
+
+        /// <summary>
+        /// Set the values of this object to the values of another <see cref="SpeedStatistic"/> object.
+        /// </summary>
+        /// <param name="speedStat">SpeedStatistic to copy the values from</param>
+        /// <param name="enablePropertyChangeEvent"><inheritdoc cref="EnablePropertyChangeEvent" path="*"/><para/> After updating the values, this property will be set back to TRUE.</param>
+        internal void SetValues(SpeedStatistic speedStat, bool enablePropertyChangeEvent)
+        {
+            EnablePropertyChangeEvent = enablePropertyChangeEvent;
+            MegaBytesPerMin = speedStat.MegaBytesPerMin;
+            BytesPerSec = speedStat.BytesPerSec;
+            EnablePropertyChangeEvent = true;
+        }
+
+        #endregion
+
         #region ADD
 
         //The Adding methods exists solely to facilitate the averaging method. Adding speeds together over consecutive runs makes little sense. 
@@ -53,31 +137,51 @@ namespace RoboSharp.Results
         /// <summary>
         /// Add the results of the supplied SpeedStatistic objects to this Statistics object.
         /// </summary>
-        /// <param name="stats">Statistics Items to add</param>
-        private void AddStatistic(IEnumerable<SpeedStatistic> stats)
+        /// <param name="stat">Statistics Item to add</param>
+        /// 
+#if !NET40
+        [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
+#endif
+        private void AddStatistic(SpeedStatistic stat)
         {
-            foreach (SpeedStatistic stat in stats)
-            {
-                this.BytesPerSec += stat.BytesPerSec;
-                this.MegaBytesPerMin += stat.MegaBytesPerMin;
-            }
+            EnablePropertyChangeEvent = false;
+            BytesPerSec += stat?.BytesPerSec ?? 0;
+            MegaBytesPerMin += stat?.MegaBytesPerMin ?? 0;
+            EnablePropertyChangeEvent = true;
         }
 
         /// <summary>
-        /// Combine the results of the supplied SpeedStatistic objects
+        /// Add the results of the supplied SpeedStatistic objects to this Statistics object.
         /// </summary>
-        /// <param name="stats">SpeedStatistic Items to add</param>
-        /// <returns>New Statistics Object</returns>
-        private static SpeedStatistic AddStatistics(IEnumerable<SpeedStatistic> stats)
+        /// <param name="stats">Statistics Items to add</param>
+#if !NET40
+        [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
+#endif
+        private void AddStatistic(IEnumerable<SpeedStatistic> stats)
         {
-            SpeedStatistic ret = new SpeedStatistic();
-            ret.AddStatistic(stats);
-            return ret;
+            EnablePropertyChangeEvent = false;
+            foreach (SpeedStatistic stat in stats)
+            {
+                BytesPerSec += stat?.BytesPerSec ?? 0;
+                MegaBytesPerMin += stat?.MegaBytesPerMin ?? 0;
+            }
+            EnablePropertyChangeEvent = true;
         }
 
         #endregion ADD
 
         #region AVERAGE
+
+        /// <summary>
+        /// Combine the supplied <see cref="SpeedStatistic"/> objects, then get the average.
+        /// </summary>
+        /// <param name="stat">Stats object</param>
+        public void AverageStatistic(SpeedStatistic stat)
+        {
+            this.AddStatistic(stat);
+            BytesPerSec /= 2;
+            MegaBytesPerMin /= 2;
+        }
 
         /// <summary>
         /// Combine the supplied <see cref="SpeedStatistic"/> objects, then get the average.
@@ -89,14 +193,14 @@ namespace RoboSharp.Results
             int cnt = stats.Count() + 1;
             BytesPerSec /= cnt;
             MegaBytesPerMin /= cnt;
-
         }
 
         /// <returns>New Statistics Object</returns>
         /// <inheritdoc cref=" AverageStatistic(IEnumerable{SpeedStatistic})"/>
         public static SpeedStatistic AverageStatistics(IEnumerable<SpeedStatistic> stats)
         {
-            SpeedStatistic stat = AddStatistics(stats);
+            SpeedStatistic stat = new SpeedStatistic();
+            stat.AddStatistic(stats);
             int cnt = stats.Count();
             if (cnt > 1)
             {

--- a/RoboSharp/Results/SpeedStatistic.cs
+++ b/RoboSharp/Results/SpeedStatistic.cs
@@ -289,8 +289,8 @@ namespace RoboSharp.Results
 #endif
         internal void CalculateAverage()
         {
-            BytesPerSec = Divisor < 1 ? 0 : Combined_BytesPerSec / Divisor;
-            MegaBytesPerMin = Divisor < 1 ? 0 : Combined_MegaBytesPerMin / Divisor;
+            BytesPerSec = Divisor < 1 ? 0 : Math.Round(Combined_BytesPerSec / Divisor, 3);
+            MegaBytesPerMin = Divisor < 1 ? 0 : Math.Round(Combined_MegaBytesPerMin / Divisor, 3);
         }
 
         /// <summary>

--- a/RoboSharp/Results/SpeedStatistic.cs
+++ b/RoboSharp/Results/SpeedStatistic.cs
@@ -28,7 +28,8 @@ namespace RoboSharp.Results
         public event PropertyChangedEventHandler PropertyChanged;
 
         /// <summary> Average Transfer Rate in Bytes/Second </summary>
-        public virtual decimal BytesPerSec {
+        public virtual decimal BytesPerSec
+        {
             get => BytesPerSecField;
             protected set
             {
@@ -41,7 +42,8 @@ namespace RoboSharp.Results
         }
 
         /// <summary> Average Transfer Rate in MB/Minute</summary>
-        public virtual decimal MegaBytesPerMin {
+        public virtual decimal MegaBytesPerMin
+        {
             get => MegaBytesPerMinField;
             protected set
             {
@@ -88,7 +90,7 @@ namespace RoboSharp.Results
         }
 
         #endregion
- 
+
     }
 
     /// <summary>
@@ -112,7 +114,7 @@ namespace RoboSharp.Results
         /// Either a <see cref="SpeedStatistic"/> or a <see cref="AverageSpeedStatistic"/> object. <br/>
         /// If a <see cref="AverageSpeedStatistic"/> is passed into this constructor, it wil be treated as the base <see cref="SpeedStatistic"/> instead.
         /// </param>
-        public AverageSpeedStatistic(SpeedStatistic speedStat) : base() 
+        public AverageSpeedStatistic(SpeedStatistic speedStat) : base()
         {
             Divisor = 1;
             Combined_BytesPerSec = speedStat.BytesPerSec;
@@ -125,9 +127,9 @@ namespace RoboSharp.Results
         /// </summary>
         /// <param name="speedStats"><inheritdoc cref="Average(IEnumerable{SpeedStatistic})"/></param>
         /// <inheritdoc cref="Average(IEnumerable{SpeedStatistic})"/>
-        public AverageSpeedStatistic(IEnumerable<SpeedStatistic> speedStats) : base() 
+        public AverageSpeedStatistic(IEnumerable<SpeedStatistic> speedStats) : base()
         {
-            Average(speedStats); 
+            Average(speedStats);
         }
 
         #endregion
@@ -247,12 +249,14 @@ namespace RoboSharp.Results
             AverageSpeedStatistic AvgStat = IsAverageStat ? (AverageSpeedStatistic)stat : null;
             Divisor -= IsAverageStat ? AvgStat.Divisor : 1;
             //Combine the values if Divisor is still valid
-            if (Divisor >= 1) {
+            if (Divisor >= 1)
+            {
                 Combined_BytesPerSec -= IsAverageStat ? AvgStat.Combined_BytesPerSec : stat.BytesPerSec;
                 Combined_MegaBytesPerMin -= IsAverageStat ? AvgStat.Combined_MegaBytesPerMin : stat.MegaBytesPerMin;
             }
             //Cannot have negative speeds or divisors -> Reset all values
-            if (Divisor < 1 || Combined_BytesPerSec < 0 || Combined_MegaBytesPerMin < 0) {
+            if (Divisor < 1 || Combined_BytesPerSec < 0 || Combined_MegaBytesPerMin < 0)
+            {
                 Combined_BytesPerSec = 0;
                 Combined_MegaBytesPerMin = 0;
                 Divisor = 0;

--- a/RoboSharp/Results/SpeedStatistic.cs
+++ b/RoboSharp/Results/SpeedStatistic.cs
@@ -10,7 +10,10 @@ using System.Runtime.CompilerServices;
 
 namespace RoboSharp.Results
 {
-    /// <summary> Contains information regarding average Transfer Speed </summary>
+    /// <summary>
+    /// Contains information regarding average Transfer Speed. <br/>
+    /// Note: Runs that do not perform any copy operations or that exited prematurely ( <see cref="RoboCopyExitCodes.Cancelled"/> ) will result in a null <see cref="SpeedStatistic"/> object.
+    /// </summary>
     public class SpeedStatistic : INotifyPropertyChanged
     {
         #region < Fields, Events, Properties >
@@ -90,7 +93,7 @@ namespace RoboSharp.Results
 
     /// <summary>
     /// This object represents the Average of several <see cref="SpeedStatistic"/> objects, and contains 
-    /// methods to facilitate that functionality. 
+    /// methods to facilitate that functionality.
     /// </summary>
     public class AverageSpeedStatistic : SpeedStatistic
     {

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -85,27 +85,27 @@ namespace RoboSharp
         #region Events
 
         /// <summary>Handles <see cref="OnFileProcessed"/></summary>
-        public delegate void FileProcessedHandler(object sender, FileProcessedEventArgs e);
+        public delegate void FileProcessedHandler(RoboCommand sender, FileProcessedEventArgs e);
         /// <summary>Occurs each time a new item has started processing</summary>
         public event FileProcessedHandler OnFileProcessed;
 
         /// <summary>Handles <see cref="OnCommandError"/></summary>
-        public delegate void CommandErrorHandler(object sender, CommandErrorEventArgs e);
+        public delegate void CommandErrorHandler(RoboCommand sender, CommandErrorEventArgs e);
         /// <summary>Occurs when an error occurs while generating the command</summary>
         public event CommandErrorHandler OnCommandError;
 
         /// <summary>Handles <see cref="OnError"/></summary>
-        public delegate void ErrorHandler(object sender, ErrorEventArgs e);
+        public delegate void ErrorHandler(RoboCommand sender, ErrorEventArgs e);
         /// <summary>Occurs when the command exits due to an error</summary>
         public event ErrorHandler OnError;
 
         /// <summary>Handles <see cref="OnCommandCompleted"/></summary>
-        public delegate void CommandCompletedHandler(object sender, RoboCommandCompletedEventArgs e);
+        public delegate void CommandCompletedHandler(RoboCommand sender, RoboCommandCompletedEventArgs e);
         /// <summary>Occurs when the command exits</summary>
         public event CommandCompletedHandler OnCommandCompleted;
 
         /// <summary>Handles <see cref="OnCopyProgressChanged"/></summary>
-        public delegate void CopyProgressHandler(object sender, CopyProgressEventArgs e);
+        public delegate void CopyProgressHandler(RoboCommand sender, CopyProgressEventArgs e);
         /// <summary>Occurs each time the current item's progress is updated</summary>
         public event CopyProgressHandler OnCopyProgressChanged;
 

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -42,7 +42,7 @@ namespace RoboSharp
         public bool IsRunning { get { return isRunning; } }
         /// <summary> Value indicating if process was Cancelled </summary>
         public bool IsCancelled { get { return isCancelled; } }
-        /// <summary>  </summary>
+        /// <summary> Get the parameters string passed to RoboCopy based on the current setup </summary>
         public string CommandOptions { get { return GenerateParameters(); } }
         /// <inheritdoc cref="RoboSharp.CopyOptions"/>
         public CopyOptions CopyOptions
@@ -362,7 +362,10 @@ namespace RoboSharp
                 process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
                 process.StartInfo.CreateNoWindow = true;
                 process.StartInfo.FileName = Configuration.RoboCopyExe;
-                process.StartInfo.Arguments = GenerateParameters();
+                resultsBuilder.Source = CopyOptions.Source;
+                resultsBuilder.Destination = CopyOptions.Destination;
+                resultsBuilder.CommandOptions = GenerateParameters();
+                process.StartInfo.Arguments = resultsBuilder.CommandOptions;
                 process.OutputDataReceived += process_OutputDataReceived;
                 process.ErrorDataReceived += process_ErrorDataReceived;
                 process.EnableRaisingEvents = true;
@@ -430,6 +433,9 @@ namespace RoboSharp
             return results;
         }
 
+        /// <summary>
+        /// Generate the Parameters and Switches to execute RoboCopy with based on the configured settings
+        /// </summary>
         private string GenerateParameters()
         {
             Debugger.Instance.DebugMessage("Generating parameters...");


### PR DESCRIPTION
Create a List Object for RoboCopyResults that allows auto-summing of the Statistics Objects contained within the list's Results objects.

- Since this may be used for binding, Implement `INotifyPropertyChanged` on the Statistics and SpeedStatistics objects