### PR TITLE
Count Files and Dirs in case of Cancellation

### DIFF
--- a/RoboSharp/ProcessedFileInfo.cs
+++ b/RoboSharp/ProcessedFileInfo.cs
@@ -5,7 +5,7 @@
     /// </summary>
     public enum FileClassType
     {
-        /// <summary>Details about a FOLDER</summary>
+        /// <summary>Details about a Directory</summary>
         NewDir,
         /// <summary>Details about a FILE</summary>
         File,
@@ -18,10 +18,17 @@
     {
         /// <summary>Description of the item as reported by RoboCopy</summary>
         public string FileClass { get; set; }
+        
         /// <inheritdoc cref="RoboSharp.FileClassType"/>
         public FileClassType FileClassType { get; set; }
-        /// <summary>File Size</summary>
+
+        /// <summary>
+        /// File -> File Size <br/>
+        /// Directory -> Number files in folder -> Can be negative if PURGE is used <br/>
+        /// SystemMessage -> Should be 0
+        /// </summary>
         public long Size { get; set; }
+
         /// <summary>Folder or File Name / Message Text</summary>
         public string Name { get; set; }
     }

--- a/RoboSharp/Results/ResultsBuilder.cs
+++ b/RoboSharp/Results/ResultsBuilder.cs
@@ -10,8 +10,13 @@ namespace RoboSharp.Results
     /// </summary>
     internal class ResultsBuilder
     {
-         
+        private ResultsBuilder() { }
+
+        internal ResultsBuilder(RoboSharpConfiguration config) { Config = config; }
+
         private readonly List<string> outputLines = new List<string>();
+
+        private RoboSharpConfiguration Config { get; }
 
         #region < Command Options Properties >
 
@@ -60,9 +65,9 @@ namespace RoboSharp.Results
         {
             TotalDirs++;
             CurrentDir = currentDir;
-            if (currentDir.FileClass.Contains("Existing")) { /* No Action */ }
-            else if (currentDir.FileClass == "New Dir") { if (CopyOperation) TotalDirs_Copied++; }
-            else if (currentDir.FileClass.Contains("EXTRA")) TotalDirs_Extras++;
+            if (currentDir.FileClass == Config.LogParsing_ExistingDir) { /* No Action */ }
+            else if (currentDir.FileClass == Config.LogParsing_NewDir) { if (CopyOperation) TotalDirs_Copied++; }
+            else if (currentDir.FileClass == Config.LogParsing_ExtraDir) TotalDirs_Extras++;
             else
             {
                 
@@ -84,21 +89,21 @@ namespace RoboSharp.Results
             CopyOpStarted = false;
 
             // EXTRA FILES
-            if (currentFile.FileClass.ToLower().Contains("extra"))
+            if (currentFile.FileClass == Config.LogParsing_ExtraFile)
             {
                 TotalFiles_Extras++;
                 TotalBytes_Extra += CurrentFile.Size;
             }
 
             //MisMatch
-            else if (currentFile.FileClass.ToLower().Contains("mismatch"))
+            else if (currentFile.FileClass == Config.LogParsing_MismatchFile)
             {
                 TotalFiles_Mismatch++;
                 TotalBytes_MisMatch += CurrentFile.Size;
             }
 
             //Failed Files
-            else if (currentFile.FileClass.ToLower().Contains("fail"))
+            else if (currentFile.FileClass == Config.LogParsing_FailedFile)
             {
                 TotalFiles_Failed++;
                 TotalBytes_Failed += currentFile.Size;
@@ -106,7 +111,7 @@ namespace RoboSharp.Results
 
 
             //Identical Files
-            else if (currentFile.FileClass == "same")
+            else if (currentFile.FileClass == Config.LogParsing_SameFile)
             {
                 TotalFiles_Skipped++; //File is the same -> It will be skipped
                 TotalBytes_Skipped += CurrentFile.Size;
@@ -117,9 +122,9 @@ namespace RoboSharp.Results
             else
             {
                 SkippingFile = CopyOperation;//Assume Skipped, adjusted when CopyProgress is updated
-                if (currentFile.FileClass.ToLower() == "new file") { }
-                else if (currentFile.FileClass.ToLower().Contains("older")) { }
-                else if (currentFile.FileClass.ToLower().Contains("newer")) { }
+                if (currentFile.FileClass == Config.LogParsing_NewFile) { }
+                else if (currentFile.FileClass == Config.LogParsing_OlderFile) { }
+                else if (currentFile.FileClass == Config.LogParsing_NewerFile) { }
             }
         }
 

--- a/RoboSharp/Results/ResultsBuilder.cs
+++ b/RoboSharp/Results/ResultsBuilder.cs
@@ -28,24 +28,84 @@ namespace RoboSharp.Results
 
         #region < Counters in case cancellation >
 
-        /// <summary> Internal counter used to generate statistics if job is cancelled </summary>
-        internal long TotalDirs { get; private set; } = 0;
-        /// <summary> Internal counter used to generate statistics if job is cancelled </summary>
-        internal long TotalDirsCopied { get; private set; } = 0;
-        /// <summary> Internal counter used to generate statistics if job is cancelled </summary>
-        internal long TotalFiles { get; private set; } = 0;
-        /// <summary> Internal counter used to generate statistics if job is cancelled </summary>
-        internal long TotalFilesCopied { get; private set; } = 0;
+        //Counters used to generate statistics if job is cancelled 
+
+        private long TotalDirs { get; set; } = 0;
+        private long TotalDirs_Copied { get; set; } = 0;
+        private long TotalDirs_Skipped { get; set; } = 0;
+        private long TotalDirs_Extras { get; set; } = 0;
+
+        private long TotalFiles { get; set; } = 0;
+        private long TotalFiles_Copied { get; set; } = 0;
+        private long TotalFiles_Skipped { get; set; } = 0;
+        private long TotalFiles_Extras { get; set; } = 0;
+        private long TotalFiles_Mismatch { get; set; } = 0;
+        private long TotalFiles_Failed { get; set; } = 0;
+
+        private long TotalBytes { get; set; } = 0;
+        private long TotalBytes_Copied { get; set; } = 0;
+        private long TotalBytes_Failed { get; set; } = 0;
+
+        private bool CopyOpStarted;
+        private ProcessedFileInfo CurrentDir;
+        private ProcessedFileInfo CurrentFile;
 
         // Methods to add to internal counters -> created as methods to allow inline null check since results?.TotalDirs++; won't compile
         /// <summary>Increment <see cref="TotalDirs"/></summary>
-        internal void AddDir() => TotalDirs++;
-        /// <summary>Increment <see cref="TotalDirsCopied"/></summary>
-        internal void AddDirCopied() => TotalDirsCopied++;
+        internal void AddDir(ProcessedFileInfo currentDir, bool CopyOperation)
+        {
+            TotalDirs++;
+            CurrentDir = currentDir;
+            if (currentDir.FileClass.Contains("Existing")) { /* No Action */ }
+            else if (currentDir.FileClass == "New Dir") { if (CopyOperation) TotalDirs_Copied++; }
+            else if (currentDir.FileClass.Contains("EXTRA")) TotalDirs_Extras++;
+            else
+            {
+                
+            }
+        }
+
         /// <summary>Increment <see cref="TotalFiles"/></summary>
-        internal void AddFile() => TotalFiles++;
-        /// <summary>Increment <see cref="TotalFilesCopied"/></summary>
-        internal void AddFileCopied() => TotalFilesCopied++;
+        internal void AddFile(ProcessedFileInfo currentFile, bool CopyOperation)
+        {
+            TotalFiles++;
+            CopyOpStarted = false;
+            CurrentFile = currentFile;
+            TotalBytes += currentFile.Size;
+
+            if (currentFile.FileClass.ToLower().Contains("extra")) TotalFiles_Extras++;
+            else if (currentFile.FileClass.ToLower().Contains("mismatch")) TotalFiles_Mismatch++;
+            else if (currentFile.FileClass.ToLower().Contains("fail"))
+            {
+                TotalFiles_Failed++;
+                TotalBytes_Failed += currentFile.Size;
+            }
+            else
+            {
+                if (CopyOperation) TotalFiles_Skipped++; //Assume Skipped, adjusted when CopyProgress is updated
+
+                if (currentFile.FileClass.ToLower() == "new file") { }
+                else if (currentFile.FileClass.ToLower().Contains("older")) { }
+                else if (currentFile.FileClass.ToLower().Contains("newer")) { }
+            }
+        }
+
+        /// <summary>Increment <see cref="TotalFiles_Copied"/></summary>
+        internal void SetCopyOpStarted()
+        {
+            if (!CopyOpStarted) TotalFiles_Skipped--; //Catch start copy progress of large files
+            CopyOpStarted = true;
+        }
+
+        /// <summary>Increment <see cref="TotalFiles_Copied"/></summary>
+        internal void AddFileCopied()
+        {
+            if (!CopyOpStarted) TotalFiles_Skipped--; //Some files are small enough they only get the first report wher it reports 100% -> this catches that scenario
+            CopyOpStarted = false;
+            TotalFiles_Copied++;
+            TotalBytes_Copied += CurrentFile?.Size ?? 0;
+            CurrentFile = null;
+        }
 
         #endregion
 
@@ -67,24 +127,37 @@ namespace RoboSharp.Results
 
             var statisticLines = GetStatisticLines();
 
+            //Dir Stats
             if (exitCode >= 0 && statisticLines.Count >= 1)
                 res.DirectoriesStatistic = Statistic.Parse(statisticLines[0]);
             else
-                res.DirectoriesStatistic = new Statistic() { Total = TotalDirs, Copied = TotalDirsCopied};
+                res.DirectoriesStatistic = new Statistic() { Total = TotalDirs, Copied = TotalDirs_Copied, Extras = TotalDirs_Extras};
 
+            //File Stats
             if (exitCode >= 0 && statisticLines.Count >= 2)
                 res.FilesStatistic = Statistic.Parse(statisticLines[1]);
             else
-                res.FilesStatistic = new Statistic() { Total = TotalFiles, Copied = TotalFilesCopied };
+            {
+                if (CopyOpStarted) TotalFiles_Failed++;
+                res.FilesStatistic = new Statistic() { Total = TotalFiles, Copied = TotalFiles_Copied, Failed = TotalFiles_Failed, Extras = TotalFiles_Extras, Skipped = TotalFiles_Skipped, Mismatch = TotalFiles_Mismatch };
+            }
 
+            //Bytes
             if (exitCode >= 0 && statisticLines.Count >= 3)
                 res.BytesStatistic = Statistic.Parse(statisticLines[2]);
+            else
+            {
+                TotalBytes_Failed += CopyOpStarted ? ( CurrentFile?.Size ?? 0 ) : 0;
+                res.BytesStatistic = new Statistic() { Copied = TotalBytes_Copied, Total = TotalBytes, Failed = TotalBytes_Failed };
+            }
 
+            //Speed Stats
             if (exitCode >= 0 && statisticLines.Count >= 6)
                 res.SpeedStatistic = SpeedStatistic.Parse(statisticLines[4], statisticLines[5]);
+            else
+                res.SpeedStatistic = new SpeedStatistic();
 
             res.LogLines = outputLines.ToArray();
-
             res.Source = this.Source;
             res.Destination = this.Destination;
             res.CommandOptions = this.CommandOptions;

--- a/RoboSharp/Results/ResultsBuilder.cs
+++ b/RoboSharp/Results/ResultsBuilder.cs
@@ -173,7 +173,7 @@ namespace RoboSharp.Results
                 if (line.StartsWith("-----------------------"))
                     break;
 
-                if (line.Contains(":"))
+                if (line.Contains(":") && !line.Contains("\\"))
                     res.Add(line);
             }
 

--- a/RoboSharp/Results/RoboCopyResults.cs
+++ b/RoboSharp/Results/RoboCopyResults.cs
@@ -7,24 +7,49 @@ namespace RoboSharp.Results
     /// </summary>
     public class RoboCopyResults
     {
+        internal RoboCopyResults() { }
+
+        #region < Properties >
+
         /// <inheritdoc cref="CopyOptions.Source"/>
         public string Source { get; internal set; }
+
         /// <inheritdoc cref="CopyOptions.Destination"/>
         public string Destination { get; internal set; }
+
         /// <inheritdoc cref="RoboCommand.CommandOptions"/>
         public string CommandOptions { get; internal set; }
+
         /// <inheritdoc cref="RoboCopyExitStatus"/>
         public RoboCopyExitStatus Status { get; internal set; }
+
         /// <summary> Information about number of Directories Copied, Skipped, Failed, etc.</summary>
+        /// <remarks> 
+        /// If the job was cancelled, this will contain incomplete/inaccurate results, showing only total number of directories handled. <br/>
+        /// The 'Copied' stat may be inaccurate, as it assumes a directory was created if not running in List-Only mode. <br/>
+        /// Extras, Mismatch, Errors &amp; Failed are not tracked if job was cancelled.
+        /// </remarks>
         public Statistic DirectoriesStatistic { get; internal set; }
+
         /// <summary> Information about number of Files Copied, Skipped, Failed, etc.</summary>
+        /// <remarks> 
+        /// If the job was cancelled, this will contain incomplete / inaccurate results, showing only total number of files handled and how many hit 100% copy progress. <br/>
+        /// Extras, Mismatch, Errors, &amp; Failed are not tracked if job was cancelled, and the number of files may be inaccurate if a failure or error occurred.
+        /// </remarks>
         public Statistic FilesStatistic { get; internal set; }
+
         /// <summary> Information about number of Bytes processed.</summary>
+        /// <remarks> If the job was cancelled, this be null.</remarks>
         public Statistic BytesStatistic { get; internal set; }
+
         /// <inheritdoc cref="RoboSharp.Results.SpeedStatistic"/>
+        /// <remarks> If the job was cancelled, this be null.</remarks>
         public SpeedStatistic SpeedStatistic { get; internal set; }
+
         /// <summary> Output Text reported by RoboCopy </summary>
         public string[] LogLines { get; internal set; }
+
+        #endregion
 
         /// <summary>
         /// Returns a string that represents the current object.
@@ -34,11 +59,11 @@ namespace RoboSharp.Results
         /// </returns>
         public override string ToString()
         {
-            string str = $"ExitCode: {Status.ExitCode}, Directories: {DirectoriesStatistic.Total}, Files: {FilesStatistic.Total}, Bytes: {BytesStatistic.Total}";
+            string str = $"ExitCode: {Status.ExitCode}, Directories: {DirectoriesStatistic?.Total.ToString() ?? "Unknown"}, Files: {FilesStatistic?.Total.ToString() ?? "Unknown"}, Bytes: {BytesStatistic?.Total.ToString() ?? "Unknown"}";
 
             if (SpeedStatistic != null)
             {
-                str = str + $", Speed: {SpeedStatistic.BytesPerSec} Bytes/sec";
+                str += $", Speed: {SpeedStatistic.BytesPerSec} Bytes/sec";
             }
 
             return str;

--- a/RoboSharp/Results/RoboCopyResults.cs
+++ b/RoboSharp/Results/RoboCopyResults.cs
@@ -10,7 +10,7 @@ namespace RoboSharp.Results
         internal RoboCopyResults() { }
 
         #region < Properties >
-
+        
         /// <inheritdoc cref="CopyOptions.Source"/>
         public string Source { get; internal set; }
 
@@ -25,25 +25,26 @@ namespace RoboSharp.Results
 
         /// <summary> Information about number of Directories Copied, Skipped, Failed, etc.</summary>
         /// <remarks> 
-        /// If the job was cancelled, this will contain incomplete/inaccurate results, showing only total number of directories handled. <br/>
-        /// The 'Copied' stat may be inaccurate, as it assumes a directory was created if not running in List-Only mode. <br/>
-        /// Extras, Mismatch, Errors &amp; Failed are not tracked if job was cancelled.
+        /// If the job was cancelled, or run without a Job Summary, this will attempt to provide approximate results based on the Process.StandardOutput from Robocopy. <br/>
+        /// Results should only be treated as accurate if <see cref="Status"/>.ExitCodeValue >= 0 and the job was run with <see cref="LoggingOptions.NoJobSummary"/> = FALSE
         /// </remarks>
         public Statistic DirectoriesStatistic { get; internal set; }
 
         /// <summary> Information about number of Files Copied, Skipped, Failed, etc.</summary>
         /// <remarks> 
-        /// If the job was cancelled, this will contain incomplete / inaccurate results, showing only total number of files handled and how many hit 100% copy progress. <br/>
-        /// Extras, Mismatch, Errors, &amp; Failed are not tracked if job was cancelled, and the number of files may be inaccurate if a failure or error occurred.
+        /// If the job was cancelled, or run without a Job Summary, this will attempt to provide approximate results based on the Process.StandardOutput from Robocopy. <br/>
+        /// Results should only be treated as accurate if <see cref="Status"/>.ExitCodeValue >= 0 and the job was run with <see cref="LoggingOptions.NoJobSummary"/> = FALSE
         /// </remarks>
         public Statistic FilesStatistic { get; internal set; }
 
         /// <summary> Information about number of Bytes processed.</summary>
-        /// <remarks> If the job was cancelled, this be null.</remarks>
+        /// <remarks> 
+        /// If the job was cancelled, or run without a Job Summary, this will attempt to provide approximate results based on the Process.StandardOutput from Robocopy. <br/>
+        /// Results should only be treated as accurate if <see cref="Status"/>.ExitCodeValue >= 0 and the job was run with <see cref="LoggingOptions.NoJobSummary"/> = FALSE
+        /// </remarks>
         public Statistic BytesStatistic { get; internal set; }
 
         /// <inheritdoc cref="RoboSharp.Results.SpeedStatistic"/>
-        /// <remarks> If the job was cancelled, this be null.</remarks>
         public SpeedStatistic SpeedStatistic { get; internal set; }
 
         /// <summary> Output Text reported by RoboCopy </summary>

--- a/RoboSharp/Results/Statistic.cs
+++ b/RoboSharp/Results/Statistic.cs
@@ -33,7 +33,7 @@ namespace RoboSharp.Results
         /// <summary> Total Scanned during the run</summary>
         public long Total { 
             get => TotalField;
-            private set
+            internal set
             {
                 if (TotalField != value)
                 {
@@ -46,7 +46,7 @@ namespace RoboSharp.Results
         /// <summary> Total Copied </summary>
         public long Copied { 
             get => CopiedField;
-            private set
+            internal set
             {
                 if (CopiedField != value)
                 {
@@ -59,7 +59,7 @@ namespace RoboSharp.Results
         /// <summary> Total Skipped </summary>
         public long Skipped { 
             get => SkippedField;
-            private set
+            internal set
             {
                 if (SkippedField != value)
                 {
@@ -72,7 +72,7 @@ namespace RoboSharp.Results
         /// <summary>  </summary>
         public long Mismatch { 
             get => MismatchField;
-            private set
+            internal set
             {
                 if (MismatchField != value)
                 {
@@ -84,8 +84,8 @@ namespace RoboSharp.Results
 
         /// <summary> Total that failed to copy or move </summary>
         public long Failed { 
-            get => FailedField; 
-            private set
+            get => FailedField;
+            internal set
             {
                 if (FailedField != value)
                 {
@@ -98,7 +98,7 @@ namespace RoboSharp.Results
         /// <summary> Total Extra that exist in the Destination (but are missing from the Source)</summary>
         public long Extras { 
             get => ExtrasField;
-            private set 
+            internal set
             {
                 if (ExtrasField != value)
                 {

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -151,7 +151,7 @@ namespace RoboSharp
                         //New Method - Parsed using Regex
                         GroupCollection MatchData = DirRegex.Match(data).Groups;
                         file.FileClass = MatchData["Type"].Value.Trim();
-                        if (file.FileClass == "") file.FileClass = "Existing Dir";
+                        if (file.FileClass == "") file.FileClass = configuration.LogParsing_ExistingDir;
                         long.TryParse(MatchData["FileCount"].Value, out long size);
                         file.Size = size;
                         file.Name = MatchData["Path"].Value.Trim();
@@ -271,7 +271,7 @@ namespace RoboSharp
             var tokenSource = new CancellationTokenSource();
             CancellationToken cancellationToken = tokenSource.Token;
 
-            resultsBuilder = new Results.ResultsBuilder();
+            resultsBuilder = new Results.ResultsBuilder(this.Configuration);
             results = null;
 
             #region Check Source and Destination
@@ -379,6 +379,7 @@ namespace RoboSharp
                 process.StartInfo.FileName = Configuration.RoboCopyExe;
                 resultsBuilder.Source = CopyOptions.Source;
                 resultsBuilder.Destination = CopyOptions.Destination;
+                this.loggingOptions.NoJobSummary = true;
                 resultsBuilder.CommandOptions = GenerateParameters();
                 process.StartInfo.Arguments = resultsBuilder.CommandOptions;
                 process.OutputDataReceived += process_OutputDataReceived;

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -130,6 +130,7 @@ namespace RoboSharp
             if (data.EndsWith("%", StringComparison.Ordinal))
             {
                 // copy progress data
+                if (data == "100%") resultsBuilder?.AddFileCopied();
                 OnCopyProgressChanged?.Invoke(this, new CopyProgressEventArgs(Convert.ToDouble(data.Replace("%", ""), CultureInfo.InvariantCulture)));
             }
             else
@@ -140,6 +141,8 @@ namespace RoboSharp
 
                     if (splitData.Length == 2)
                     {
+                        resultsBuilder?.AddDir();
+                        if (!this.LoggingOptions.ListOnly) resultsBuilder?.AddDirCopied();
                         var file = new ProcessedFileInfo();
                         file.FileClass = "New Dir";
                         file.FileClassType = FileClassType.NewDir;
@@ -151,6 +154,7 @@ namespace RoboSharp
                     }
                     else if (splitData.Length == 3)
                     {
+                        resultsBuilder?.AddFile();
                         var file = new ProcessedFileInfo();
                         file.FileClass = splitData[0].Trim();
                         file.FileClassType = FileClassType.File;

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -135,96 +135,88 @@ namespace RoboSharp
             }
             else
             {
-                if (OnFileProcessed != null)
+
+                var splitData = data.Split(new char[] { '\t' }, StringSplitOptions.RemoveEmptyEntries);
+
+                if (splitData.Length == 2) // Directory
                 {
-                    var splitData = data.Split(new char[] { '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                    // Regex to parse the string for FileCount, Path, and Type (Description)
+                    Regex DirRegex = new Regex("^(?<Type>\\*?[a-zA-Z]{0,10}\\s?[a-zA-Z]{0,3})\\s*(?<FileCount>[-]{0,1}[0-9]{1,100})\\t(?<Path>.+)", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
 
-                    if (splitData.Length == 2)
-                    {
-                        // Regex to parse the string for FileCount, Path, and Type (Description)
-                        Regex DirRegex = new Regex("^(?<Type>\\*?[a-zA-Z]{0,10}\\s?[a-zA-Z]{0,3})\\s*(?<FileCount>[-]{0,1}[0-9]{1,100})\\t(?<Path>.+)", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
-                        
-                        var file = new ProcessedFileInfo();
-                        file.FileClassType = FileClassType.NewDir;
+                    var file = new ProcessedFileInfo();
+                    file.FileClassType = FileClassType.NewDir;
 
-                        if (DirRegex.IsMatch(data))
-                        {
-                            //New Method - Parsed using Regex
-                            GroupCollection MatchData = DirRegex.Match(data).Groups;
-                            file.FileClass = MatchData["Type"].Value.Trim();
-                            if (file.FileClass == "") file.FileClass = "Existing Dir";
-                            long.TryParse(MatchData["FileCount"].Value, out long size);
-                            file.Size = size;
-                            file.Name = MatchData["Path"].Value.Trim();
-                        }
-                        else
-                        {
-                            //Old Method -> Left Intact for other language compatibilty / unforseen cases
-                            file.FileClass = "New Dir";
-                            long.TryParse(splitData[0].Replace("New Dir", "").Trim(), out long size);
-                            file.Size = size;
-                            file.Name = splitData[1];
-                        }
-                        
-                        OnFileProcessed(this, new FileProcessedEventArgs(file));
-                        resultsBuilder?.AddDir(file, !this.LoggingOptions.ListOnly);
-                    }
-                    else if (splitData.Length == 3)
+                    if (DirRegex.IsMatch(data))
                     {
-                        var file = new ProcessedFileInfo();
-                        file.FileClass = splitData[0].Trim();
-                        file.FileClassType = FileClassType.File;
-                        long size = 0;
-                        long.TryParse(splitData[1].Trim(), out size);
+                        //New Method - Parsed using Regex
+                        GroupCollection MatchData = DirRegex.Match(data).Groups;
+                        file.FileClass = MatchData["Type"].Value.Trim();
+                        if (file.FileClass == "") file.FileClass = "Existing Dir";
+                        long.TryParse(MatchData["FileCount"].Value, out long size);
                         file.Size = size;
-                        file.Name = splitData[2];
-                        OnFileProcessed(this, new FileProcessedEventArgs(file));
-                        resultsBuilder?.AddFile(file, !LoggingOptions.ListOnly);
+                        file.Name = MatchData["Path"].Value.Trim();
                     }
                     else
                     {
-                        var regex = new Regex($" {Configuration.ErrorToken} " + @"(\d{1,3}) \(0x\d{8}\) ");
+                        //Old Method -> Left Intact for other language compatibilty / unforseen cases
+                        file.FileClass = "New Dir";
+                        long.TryParse(splitData[0].Replace("New Dir", "").Trim(), out long size);
+                        file.Size = size;
+                        file.Name = splitData[1];
+                    }
 
-                        if (OnError != null && regex.IsMatch(data))
-                        {
-                            // parse error code
-                            var match = regex.Match(data);
-                            string value = match.Groups[1].Value;
-                            int parsedValue = Int32.Parse(value);
+                    resultsBuilder?.AddDir(file, !this.LoggingOptions.ListOnly);
+                    OnFileProcessed.Invoke(this, new FileProcessedEventArgs(file));
+                }
+                else if (splitData.Length == 3) // File
+                {
+                    var file = new ProcessedFileInfo();
+                    file.FileClass = splitData[0].Trim();
+                    file.FileClassType = FileClassType.File;
+                    long size = 0;
+                    long.TryParse(splitData[1].Trim(), out size);
+                    file.Size = size;
+                    file.Name = splitData[2];
+                    resultsBuilder?.AddFile(file, !LoggingOptions.ListOnly);
+                    OnFileProcessed.Invoke(this, new FileProcessedEventArgs(file));
+                }
+                else if (OnError != null && Configuration.ErrorTokenRegex.IsMatch(data)) // Error Message
+                {
 
-                            var errorCode = ApplicationConstants.ErrorCodes.FirstOrDefault(x => data.Contains(x.Key));
-                            if (errorCode.Key != null)
-                            {
-                                OnError(this, new ErrorEventArgs(string.Format("{0}{1}{2}", data, Environment.NewLine, errorCode.Value), parsedValue));
-                            }
-                            else
-                            {
-                                OnError(this, new ErrorEventArgs(data, parsedValue));
-                            }
+                    // parse error code
+                    var match = Configuration.ErrorTokenRegex.Match(data);
+                    string value = match.Groups[1].Value;
+                    int parsedValue = Int32.Parse(value);
 
-                        }
-                        else
-                        {
-                            if (!data.StartsWith("----------"))
-                            {
-                                // Do not log errors that have already been logged
-                                var errorCode = ApplicationConstants.ErrorCodes.FirstOrDefault(x => data == x.Value);
+                    var errorCode = ApplicationConstants.ErrorCodes.FirstOrDefault(x => data.Contains(x.Key));
+                    if (errorCode.Key != null)
+                    {
+                        OnError(this, new ErrorEventArgs(string.Format("{0}{1}{2}", data, Environment.NewLine, errorCode.Value), parsedValue));
+                    }
+                    else
+                    {
+                        OnError(this, new ErrorEventArgs(data, parsedValue));
+                    }
 
-                                if (errorCode.Key == null)
-                                {
-                                    var file = new ProcessedFileInfo();
-                                    file.FileClass = "System Message";
-                                    file.FileClassType = FileClassType.SystemMessage;
-                                    file.Size = 0;
-                                    file.Name = data;
-                                    OnFileProcessed(this, new FileProcessedEventArgs(file));
-                                }
-                            }
-                        }
+                }
+                else if (!data.StartsWith("----------")) // System Message
+                {
+                    // Do not log errors that have already been logged
+                    var errorCode = ApplicationConstants.ErrorCodes.FirstOrDefault(x => data == x.Value);
+
+                    if (errorCode.Key == null)
+                    {
+                        var file = new ProcessedFileInfo();
+                        file.FileClass = "System Message";
+                        file.FileClassType = FileClassType.SystemMessage;
+                        file.Size = 0;
+                        file.Name = data;
+                        OnFileProcessed(this, new FileProcessedEventArgs(file));
                     }
                 }
             }
         }
+        
     
 
         /// <summary>Pause execution of the RoboCopy process when <see cref="IsPaused"/> == false</summary>

--- a/RoboSharp/RoboSharpConfiguration.cs
+++ b/RoboSharp/RoboSharpConfiguration.cs
@@ -17,14 +17,34 @@ namespace RoboSharp
         };
 
         /// <summary>
-        /// 
+        /// Error Token Identifier -- EN = "ERROR", DE = "FEHLER", etc <br/>
+        /// Leave as / Set to null to use system default.
         /// </summary>
         public string ErrorToken
         {
             get { return errorToken ?? GetDefaultConfiguration().ErrorToken; }
-            set { errorToken = value; }
+            set {
+                if (value != errorToken) ErrRegexInitRequired = true;
+                errorToken = value;
+            }
         }
         private string errorToken = null;
+
+        /// <summary>
+        /// Regex to identify Error Tokens with during LogLine parsing
+        /// </summary>
+        internal Regex ErrorTokenRegex
+        {
+            get
+            {
+                if (ErrRegexInitRequired | errorTokenRegex == null)
+                    errorTokenRegex = new Regex($" {this.ErrorToken} " + @"(\d{1,3}) \(0x\d{8}\) ");
+                ErrRegexInitRequired = false;
+                return errorTokenRegex;
+            }
+        }
+        private Regex errorTokenRegex;
+        private bool ErrRegexInitRequired;
 
         /// <summary>
         /// Specify the path to RoboCopy.exe here. If not set, use the default copy.

--- a/RoboSharp/RoboSharpConfiguration.cs
+++ b/RoboSharp/RoboSharpConfiguration.cs
@@ -9,10 +9,11 @@ namespace RoboSharp
     /// </summary>
     public class RoboSharpConfiguration
     {
+
         private static readonly IDictionary<string, RoboSharpConfiguration> 
             defaultConfigurations = new Dictionary<string, RoboSharpConfiguration>()
         {
-            {"en", new RoboSharpConfiguration { ErrorToken = "ERROR"} },
+            {"en", new RoboSharpConfiguration { ErrorToken = "ERROR"} }, //en uses Defaults for LogParsing properties
             {"de", new RoboSharpConfiguration { ErrorToken = "FEHLER"} },
         };
 
@@ -45,6 +46,118 @@ namespace RoboSharp
         }
         private Regex errorTokenRegex;
         private bool ErrRegexInitRequired;
+
+        #region < Tokens for Log Parsing >
+
+        #region < File Tokens >
+
+        /// <summary>
+        /// Log Lines starting with this string indicate : New File -> Souce FILE Exists, Destination does not
+        /// </summary>
+        public string LogParsing_NewFile
+        {
+            get { return newFileToken ?? "New File"; }
+            set { newFileToken = value; }
+        }
+        private string newFileToken;
+
+        /// <summary>
+        /// Log Lines starting with this string indicate : Destination File newer than Source
+        /// </summary>
+        public string LogParsing_OlderFile
+        {
+            get { return olderToken ?? "Older"; }
+            set { olderToken = value; }
+        }
+        private string olderToken;
+
+        /// <summary>
+        /// Log Lines starting with this string indicate : Source File newer than Destination
+        /// </summary>
+        public string LogParsing_NewerFile
+        {
+            get { return newerToken ?? "Newer"; }
+            set { newerToken = value; }
+        }
+        private string newerToken;
+
+        /// <summary>
+        /// Log Lines starting with this string indicate : Source FILE is identical to Destination File
+        /// </summary>
+        public string LogParsing_SameFile
+        {
+            get { return sameToken ?? "same"; }
+            set { sameToken = value; }
+        }
+        private string sameToken;
+
+        /// <summary>
+        /// Log Lines starting with this string indicate : EXTRA FILE -> Destination Exists, but Source does not
+        /// </summary>
+        public string LogParsing_ExtraFile
+        {
+            get { return extraToken ?? "*EXTRA File"; }
+            set { extraToken = value; }
+        }
+        private string extraToken;
+
+        /// <summary>
+        /// Log Lines starting with this string indicate : MISMATCH FILE
+        /// </summary>
+        public string LogParsing_MismatchFile
+        {
+            get { return mismatchToken ?? "*Mismatch"; } // TO DO: Needs Verification
+            set { mismatchToken = value; }
+        }
+        private string mismatchToken;
+
+        /// <summary>
+        /// Log Lines starting with this string indicate : File Failed to Copy
+        /// </summary>
+        public string LogParsing_FailedFile
+        {
+            get { return failedToken ?? "*Failed"; } // TO DO: Needs Verification
+            set { failedToken = value; }
+        }
+        private string failedToken;
+
+        #endregion
+
+        #region < Directory Tokens >
+
+        /// <summary>
+        /// Log Lines starting with this string indicate : New Dir -> Directory will be copied to Destination
+        /// </summary>
+        public string LogParsing_NewDir
+        {
+            get { return newerDirToken ?? "New Dir"; } 
+            set { newerDirToken = value; }
+        }
+        private string newerDirToken;
+
+        /// <summary>
+        /// Log Lines starting with this string indicate : Extra Dir -> Does not exist in source
+        /// </summary>
+        public string LogParsing_ExtraDir
+        {
+            get { return extraDirToken ?? "*EXTRA Dir"; }
+            set { extraDirToken = value; }
+        }
+        private string extraDirToken;
+
+        /// <summary>
+        /// Existing Dirs do not have an identifier on the line. Instead, this string will be used when creating the <see cref="ProcessedFileInfo"/> object to indicate an Existing Directory.
+        /// </summary>
+        public string LogParsing_ExistingDir
+        {
+            get { return existingDirToken ?? "Existing Dir"; }
+            set { existingDirToken = value; }
+        }
+        private string existingDirToken;
+
+        #endregion
+
+        #endregion </ Tokens for Log Parsing >
 
         /// <summary>
         /// Specify the path to RoboCopy.exe here. If not set, use the default copy.


### PR DESCRIPTION
Will provide baseline count for Files and Directories even if job was cancelled.

Since i had my hands in the `RoboCommand.process_OutputDataReceived` method yesterday, I got a good understanding what it does, and knew that tracking the counts could be relatively easy. This PR includes tracking counts to report totals in case of a cancellation.

The fix for the `RoboCopyResults.ToString()` method is here in case that's all that is deemed accepted, I just wanted to mock up the results tracking for your review in addition to it.

```
public override string ToString()
        {
            string str = $"ExitCode: {Status.ExitCode}, Directories: {DirectoriesStatistic?.Total.ToString() ?? "Unknown"}, Files: {FilesStatistic?.Total.ToString() ?? "Unknown"}, Bytes: {BytesStatistic?.Total.ToString() ?? "Unknown"}";

            if (SpeedStatistic != null)
            {
                str += $", Speed: {SpeedStatistic.BytesPerSec} Bytes/sec";
            }

            return str;
        }
```