### PR TITLE
Robo command updates

### DIFF
--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -204,7 +204,6 @@ namespace RoboSharp
                     {
                         OnError(this, new ErrorEventArgs(data, parsedValue));
                     }
-
                 }
                 else if (!data.StartsWith("----------")) // System Message
                 {
@@ -223,8 +222,6 @@ namespace RoboSharp
                 }
             }
         }
-        
-    
 
         /// <summary>Pause execution of the RoboCopy process when <see cref="IsPaused"/> == false</summary>
         public void Pause()
@@ -272,7 +269,7 @@ namespace RoboSharp
         {
             Debugger.Instance.DebugMessage("RoboCommand started execution.");
             hasError = false;
-            
+
             isRunning = true;
 
             var tokenSource = new CancellationTokenSource();
@@ -283,12 +280,12 @@ namespace RoboSharp
 
             #region Check Source and Destination
 
-            #if NET40_OR_GREATER
+#if NET40_OR_GREATER
             // Authentificate on Target Server -- Create user if username is provided, else null
             ImpersonatedUser impersonation = username.IsNullOrWhiteSpace() ? null : impersonation = new ImpersonatedUser(username, domain, password);
-            #endif
-			
-	    // make sure source path is valid
+#endif
+
+            // make sure source path is valid
             if (!Directory.Exists(CopyOptions.Source))
             {
                 Debugger.Instance.DebugMessage("The Source directory does not exist.");
@@ -337,15 +334,15 @@ namespace RoboSharp
             }
 
             #endregion
-			
-	    #if NET40_OR_GREATER
+
+#if NET40_OR_GREATER
             //Dispose Authentification
             impersonation?.Dispose();
-            #endif
+#endif
 
             #endregion
 
-	    isRunning = !cancellationToken.IsCancellationRequested;
+            isRunning = !cancellationToken.IsCancellationRequested;
 
             backupTask = Task.Factory.StartNew(() =>
             {
@@ -353,8 +350,8 @@ namespace RoboSharp
 
                 //Raise EstimatorCreatedEvent to alert consumers that the Estimator can now be bound to
                 ProgressEstimator = resultsBuilder.Estimator;
-                OnProgressEstimatorCreated?.Invoke(this, new Results.ProgressEstimatorCreatedEventArgs(ProgressEstimator)); 
-                
+                OnProgressEstimatorCreated?.Invoke(this, new Results.ProgressEstimatorCreatedEventArgs(ProgressEstimator));
+
                 process = new Process();
 
                 if (!string.IsNullOrEmpty(domain))

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -15,7 +15,39 @@ namespace RoboSharp
     /// </summary>
     public class RoboCommand : IDisposable, IRoboCommand
     {
-        #region Private Vars
+        #region < Constructors >
+
+        /// <summary>Create a new RoboCommand object</summary>
+        public RoboCommand() { Init(); }
+
+        /// <inheritdoc cref="Init"/>
+        public RoboCommand(string name, bool stopIfDisposing = true)
+        {
+            Init(name);
+        }
+
+        /// <inheritdoc cref="Init"/>
+        public RoboCommand(string source, string destination, string name = "", bool stopIfDisposing = true)
+        {
+            Init(name, stopIfDisposing, source, destination);
+        }
+
+        /// <summary>Create a new RoboCommand object</summary>
+        /// <param name="name"><inheritdoc cref="Name" path="*"/></param>
+        /// <param name="stopIfDisposing"><inheritdoc cref="StopIfDisposing" path="*"/></param>
+        /// <param name="source"><inheritdoc cref="RoboSharp.CopyOptions.Source"/></param>
+        /// <param name="destination"><inheritdoc cref="RoboSharp.CopyOptions.Destination"/></param>
+        private void Init(string name = "", bool stopIfDisposing = false, string source = "", string destination = "")
+        {
+            Name = name;
+            StopIfDisposing = stopIfDisposing;
+            CopyOptions.Source = source;
+            CopyOptions.Destination = destination;
+        }
+
+        #endregion
+
+        #region < Private Vars >
 
         private Process process;
         private Task backupTask;
@@ -35,7 +67,10 @@ namespace RoboSharp
 
         #endregion Private Vars
 
-        #region Public Vars
+        #region < Public Vars >
+
+        /// <summary> ID Tag for the job - Allows consumers to find/sort/remove/etc commands within a list via string comparison</summary>
+        public string Name { get; set; }
         /// <summary> Value indicating if process is currently paused </summary>
         public bool IsPaused { get { return isPaused; } }
         /// <summary> Value indicating if process is currently running </summary>
@@ -87,7 +122,7 @@ namespace RoboSharp
 
         #endregion Public Vars
 
-        #region Events
+        #region < Events >
 
         /// <summary>Handles <see cref="OnFileProcessed"/></summary>
         public delegate void FileProcessedHandler(RoboCommand sender, FileProcessedEventArgs e);
@@ -478,7 +513,7 @@ namespace RoboSharp
                 parsedRetryOptions, parsedLoggingOptions);
         }
 
-        #region IDisposable Implementation
+        #region < IDisposable Implementation >
 
         bool disposed = false;
 

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -208,7 +208,7 @@ namespace RoboSharp
                     }
 
                     resultsBuilder?.AddDir(file, !this.LoggingOptions.ListOnly);
-                    OnFileProcessed.Invoke(this, new FileProcessedEventArgs(file));
+                    OnFileProcessed?.Invoke(this, new FileProcessedEventArgs(file));
                 }
                 else if (splitData.Length == 3) // File
                 {
@@ -220,7 +220,7 @@ namespace RoboSharp
                     file.Size = size;
                     file.Name = splitData[2];
                     resultsBuilder?.AddFile(file, !LoggingOptions.ListOnly);
-                    OnFileProcessed.Invoke(this, new FileProcessedEventArgs(file));
+                    OnFileProcessed?.Invoke(this, new FileProcessedEventArgs(file));
                 }
                 else if (OnError != null && Configuration.ErrorTokenRegex.IsMatch(data)) // Error Message
                 {
@@ -252,7 +252,7 @@ namespace RoboSharp
                         file.FileClassType = FileClassType.SystemMessage;
                         file.Size = 0;
                         file.Name = data;
-                        OnFileProcessed(this, new FileProcessedEventArgs(file));
+                        OnFileProcessed?.Invoke(this, new FileProcessedEventArgs(file));
                     }
                 }
             }
@@ -444,12 +444,8 @@ namespace RoboSharp
             {
                 if (!hasError)
                 {
-                    // backup is complete
-                    if (OnCommandCompleted != null)
-                    {
-                        OnCommandCompleted(this, new RoboCommandCompletedEventArgs(results));
                         isRunning = false;
-                    }
+                    OnCommandCompleted?.Invoke(this, new RoboCommandCompletedEventArgs(results)); // backup is complete -> Raise event if needed
                 }
 
                 Stop();

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -136,7 +136,7 @@ namespace RoboSharp
 
         /// <summary>Handles <see cref="OnError"/></summary>
         public delegate void ErrorHandler(RoboCommand sender, ErrorEventArgs e);
-        /// <summary>Occurs when the command exits due to an error</summary>
+        /// <summary>Occurs an error is detected by RoboCopy </summary>
         public event ErrorHandler OnError;
 
         /// <summary>Handles <see cref="OnCommandCompleted"/></summary>
@@ -177,7 +177,7 @@ namespace RoboSharp
             }
             else
             {
-
+                //Parse the string to determine which event to raise
                 var splitData = data.Split(new char[] { '\t' }, StringSplitOptions.RemoveEmptyEntries);
 
                 if (splitData.Length == 2) // Directory

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -423,7 +423,6 @@ namespace RoboSharp
                 process.StartInfo.FileName = Configuration.RoboCopyExe;
                 resultsBuilder.Source = CopyOptions.Source;
                 resultsBuilder.Destination = CopyOptions.Destination;
-                this.loggingOptions.NoJobSummary = true;
                 resultsBuilder.CommandOptions = GenerateParameters();
                 process.StartInfo.Arguments = resultsBuilder.CommandOptions;
                 process.OutputDataReceived += process_OutputDataReceived;


### PR DESCRIPTION
Bring in various fixes from #128 for RoboCommand object

- This should also resolve #102  -- Needs Verification 

**Update Dispose and Stop methods**
- Dispose and Stop previously looked at the HasExited private bool.
Since that is private to the object, and not describing the process itself, these have now been updated to evaluate Process.HasExited instead.
- Stop() is now updated so that it always reliably exits.

**Disable NJS Default**
-  This was turned on for testing and we forgot to turn it back off

**Update Start() Method**

- Reset `isCancelled`, `isPaused` bools when the command is started.
- Always run the continuation task to allow the OnCommandCompleted event to fire and to allow the Stop() method to dispose of the process.
- Move the Stop() command in the continuation task prior to raising the OnCommandCompleted event to ensure that all cleanup within RoboCopy has completed first.