### PR TITLE
Add CurrentFile to CopyProgressEventArgs

### DIFF
--- a/RoboSharp/CopyProgressEventArgs.cs
+++ b/RoboSharp/CopyProgressEventArgs.cs
@@ -7,16 +7,33 @@ namespace RoboSharp
     /// </summary>
     public class CopyProgressEventArgs : EventArgs
     {
-        /// <summary>
-        /// Current File Progress Percentage
-        /// </summary>
-        public double CurrentFileProgress { get; set; }
-
         /// <summary><inheritdoc cref="CopyProgressEventArgs"/></summary>
         /// <param name="progress"><inheritdoc cref="CurrentFileProgress"/></param>
         public CopyProgressEventArgs(double progress)
         {
             CurrentFileProgress = progress;
         }
+
+        /// <summary><inheritdoc cref="CopyProgressEventArgs"/></summary>
+        /// <param name="progress"><inheritdoc cref="CurrentFileProgress"/></param>
+        /// <param name="currentFile"><inheritdoc cref="CurrentFile"/></param>
+        /// <param name="SourceDir"><inheritdoc cref="CurrentDirectory"/></param>
+        public CopyProgressEventArgs(double progress, ProcessedFileInfo currentFile, ProcessedFileInfo SourceDir)
+        {
+            CurrentFileProgress = progress;
+            CurrentFile = currentFile;
+            CurrentDirectory = SourceDir;
+        }
+
+        /// <summary>
+        /// Current File Progress Percentage
+        /// </summary>
+        public double CurrentFileProgress { get; internal set; }
+
+        /// <inheritdoc cref="ProcessedFileInfo"/>
+        public ProcessedFileInfo CurrentFile { get; internal set; }
+
+        /// <summary>Contains information about the Last Directory RoboCopy reported into the log. </summary>
+        public ProcessedFileInfo CurrentDirectory{ get; internal set; }
     }
 }

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -136,8 +136,13 @@ namespace RoboSharp
 
             if (data.EndsWith("%", StringComparison.Ordinal))
             {
-                // copy progress data
-                OnCopyProgressChanged?.Invoke(this, new CopyProgressEventArgs(Convert.ToDouble(data.Replace("%", ""), CultureInfo.InvariantCulture)));
+                // copy progress data -> Use the CurrentFile and CurrentDir from the ResultsBuilder
+                OnCopyProgressChanged?.Invoke(this, 
+                    new CopyProgressEventArgs(
+                        Convert.ToDouble(data.Replace("%", ""), CultureInfo.InvariantCulture), 
+                        resultsBuilder?.Estimator?.CurrentFile,
+                        resultsBuilder?.Estimator?.CurrentDir
+                    ));
                 if (data == "100%") resultsBuilder?.AddFileCopied(); else resultsBuilder?.SetCopyOpStarted();
             }
             else


### PR DESCRIPTION
Update CopyProgressEventArgs with CurrentFile and CurrentDir properties now that they are available thanks to the ProgressEstimator

Resolves #131