### PR TITLE
Introduce ReadOnly Interfaces

### DIFF
--- a/RoboSharp/Results/ProgressEstimator.cs
+++ b/RoboSharp/Results/ProgressEstimator.cs
@@ -7,21 +7,6 @@ using System.Text;
 namespace RoboSharp.Results
 {
     /// <summary>
-    /// Provde Read-Only Access to the a <see cref="ProgressEstimator"/> object
-    /// </summary>
-    public interface IProgressEstimator
-    {
-        /// <inheritdoc cref="ProgressEstimator.DirStats"/>
-        IStatistic DirStats { get; }
-
-        /// <inheritdoc cref="ProgressEstimator.FileStats"/>
-        IStatistic FileStats { get; }
-
-        /// <inheritdoc cref="ProgressEstimator.ByteStats"/>
-        IStatistic ByteStats { get; }
-    }
-    
-    /// <summary>
     /// Object that provides <see cref="Statistic"/> objects whose events can be bound to report estimated RoboCommand progress periodically.
     /// </summary>
     /// <remarks>
@@ -35,7 +20,7 @@ namespace RoboSharp.Results
     /// }<br/>
     /// </code>
     /// </remarks>
-    public class ProgressEstimator : IDisposable, IProgressEstimator
+    public class ProgressEstimator
     {
         private ProgressEstimator() { }
 
@@ -54,8 +39,8 @@ namespace RoboSharp.Results
         private List<IStatistic> SubscribedStats;
         internal ProcessedFileInfo CurrentDir;
         internal ProcessedFileInfo CurrentFile;
-        private bool disposedValue;
 
+        private readonly RoboSharpConfiguration Config;
         private readonly Statistic DirStatField;
         private readonly Statistic FileStatsField;
         private readonly Statistic ByteStatsField;
@@ -83,13 +68,11 @@ namespace RoboSharp.Results
         public IStatistic ByteStats => ByteStatsField;
 
         /// <summary>
-        /// <inheritdoc cref="RoboSharpConfiguration"/>
         /// </summary>
-        public RoboSharpConfiguration Config { get; }
 
         #endregion
 
-        #region < Counting Methods >
+        #region < Counting Methods ( Internal ) >
 
         /// <summary>Increment <see cref="DirStatField"/></summary>
         internal void AddDir(ProcessedFileInfo currentDir, bool CopyOperation)
@@ -237,7 +220,7 @@ namespace RoboSharp.Results
 
         }
 
-        #region < Event Binding for Auto-Updates >
+        #region < Event Binding for Auto-Updates ( Internal ) >
 
         private void BindDirStat(object o, PropertyChangedEventArgs e) => this.DirStatField.AddStatistic((StatChangedEventArg)e);
         private void BindFileStat(object o, PropertyChangedEventArgs e) => this.FileStatsField.AddStatistic((StatChangedEventArg)e);
@@ -246,7 +229,7 @@ namespace RoboSharp.Results
         /// <summary>
         /// Subscribe to the update events of a <see cref="ProgressEstimator"/> object
         /// </summary>
-        internal void BindToProgressEstimator(IProgressEstimator estimator)
+        internal void BindToProgressEstimator(ProgressEstimator estimator)
         {
             BindToStatistic(estimator.ByteStats);
             BindToStatistic(estimator.DirStats);
@@ -258,7 +241,6 @@ namespace RoboSharp.Results
         /// </summary>
         internal void BindToStatistic(IStatistic StatObject)
         {
-            //SubScribe
             if (StatObject.Type == Statistic.StatType.Directories) StatObject.PropertyChanged += BindDirStat; //Directories
             else if (StatObject.Type == Statistic.StatType.Files) StatObject.PropertyChanged += BindFileStat; //Files
             else if (StatObject.Type == Statistic.StatType.Bytes) StatObject.PropertyChanged += BindByteStat; // Bytes
@@ -286,45 +268,6 @@ namespace RoboSharp.Results
 
         #endregion
 
-        #region < Disposing >
-        
-        /// <summary></summary>
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!disposedValue)
-            {
-                if (disposing)
-                {
-                    // TODO: dispose managed state (managed objects)
-                    UnBind(); //Unbind to show that those Statistics objects aren't required anymore
-                    SubscribedStats = null;
-                }
-
-
-                // TODO: free unmanaged resources (unmanaged objects) and override finalizer
-                // TODO: set large fields to null
-                disposedValue = true;
-            }
-        }
-
-        // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
-        // ~ProgressEstimator()
-        // {
-        //     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-        //     Dispose(disposing: false);
-        // }
-
-        /// <summary>
-        /// <inheritdoc cref="IDisposable.Dispose"/>
-        /// </summary>
-        public void Dispose()
-        {
-            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
-        }
-
-        #endregion
     }
 
 }

--- a/RoboSharp/Results/ProgressEstimator.cs
+++ b/RoboSharp/Results/ProgressEstimator.cs
@@ -262,13 +262,6 @@ namespace RoboSharp.Results
             if (StatObject.Type == Statistic.StatType.Directories) StatObject.PropertyChanged += BindDirStat; //Directories
             else if (StatObject.Type == Statistic.StatType.Files) StatObject.PropertyChanged += BindFileStat; //Files
             else if (StatObject.Type == Statistic.StatType.Bytes) StatObject.PropertyChanged += BindByteStat; // Bytes
-            
-            //Add to binding list
-            if (StatObject.Type != Statistic.StatType.Unknown)
-            {
-                if (SubscribedStats == null) SubscribedStats = new List<IStatistic>();
-                SubscribedStats.Add(StatObject);
-            }
         }
 
         /// <summary>

--- a/RoboSharp/Results/ProgressEstimatorCreatedEventArgs.cs
+++ b/RoboSharp/Results/ProgressEstimatorCreatedEventArgs.cs
@@ -20,7 +20,7 @@ namespace RoboSharp.Results
         /// <summary>
         /// <inheritdoc cref="ProgressEstimator"/>
         /// </summary>
-        public ProgressEstimator ResultsEstimate { get; }
+        public IProgressEstimator ResultsEstimate { get; }
         
     }
 }

--- a/RoboSharp/Results/ProgressEstimatorCreatedEventArgs.cs
+++ b/RoboSharp/Results/ProgressEstimatorCreatedEventArgs.cs
@@ -20,7 +20,7 @@ namespace RoboSharp.Results
         /// <summary>
         /// <inheritdoc cref="ProgressEstimator"/>
         /// </summary>
-        public IProgressEstimator ResultsEstimate { get; }
+        public ProgressEstimator ResultsEstimate { get; }
         
     }
 }

--- a/RoboSharp/Results/RoboCopyResultsList.cs
+++ b/RoboSharp/Results/RoboCopyResultsList.cs
@@ -36,9 +36,9 @@ namespace RoboSharp.Results
 
         private void Init()
         {
-            Total_DirStatsField = new Lazy<Statistic>(() => Statistic.AddStatistics(this.GetDirectoriesStatistics()));
-            Total_ByteStatsField = new Lazy<Statistic>(() => Statistic.AddStatistics(this.GetByteStatistics()));
-            Total_FileStatsField = new Lazy<Statistic>(() => Statistic.AddStatistics(this.GetFilesStatistics()));
+            Total_DirStatsField = new Lazy<Statistic>(() => Statistic.AddStatistics(this.GetDirectoriesStatistics(), Statistic.StatType.Directories));
+            Total_ByteStatsField = new Lazy<Statistic>(() => Statistic.AddStatistics(this.GetByteStatistics(), Statistic.StatType.Bytes));
+            Total_FileStatsField = new Lazy<Statistic>(() => Statistic.AddStatistics(this.GetFilesStatistics(), Statistic.StatType.Files));
             Average_SpeedStatsField = new Lazy<AverageSpeedStatistic>( () => AverageSpeedStatistic.GetAverage(this.GetSpeedStatistics()));
             ExitStatusSummaryField = new Lazy<RoboCopyCombinedExitStatus>(() => RoboCopyCombinedExitStatus.CombineStatuses(this.GetStatuses()));
         }

--- a/RoboSharp/Results/RoboCopyResultsList.cs
+++ b/RoboSharp/Results/RoboCopyResultsList.cs
@@ -4,9 +4,79 @@ using System.Linq;
 using System.Text;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.ComponentModel;
 
 namespace RoboSharp.Results
 {
+    /// <summary>
+    /// Interface to provide Read-Only access to a <see cref="RoboCopyResultsList"/>
+    /// </summary>
+    public interface IRoboCopyResultsList
+    {
+        #region < Properties >
+
+        /// <summary> Sum of all DirectoryStatistics objects </summary>
+        IStatistic DirectoriesStatistic { get; }
+
+        /// <summary> Sum of all ByteStatistics objects </summary>
+        IStatistic BytesStatistic { get; }
+
+        /// <summary> Sum of all FileStatistics objects </summary>
+        IStatistic FilesStatistic { get; }
+
+        /// <summary> Average of all SpeedStatistics objects </summary>
+        ISpeedStatistic SpeedStatistic { get; }
+
+        /// <summary> Sum of all RoboCopyExitStatus objects </summary>
+        IRoboCopyCombinedExitStatus Status { get; }
+        
+        #endregion
+
+        #region < Methods >
+
+        /// <summary>
+        /// Get a snapshot of the ByteStatistics objects from this list.
+        /// </summary>
+        /// <returns>New array of the ByteStatistic objects</returns>
+        IStatistic[] GetByteStatistics();
+
+        /// <summary>
+        /// Get a snapshot of the DirectoriesStatistic objects from this list.
+        /// </summary>
+        /// <returns>New array of the DirectoriesStatistic objects</returns>
+        IStatistic[] GetDirectoriesStatistics();
+
+        /// <summary>
+        /// Get a snapshot of the FilesStatistic objects from this list.
+        /// </summary>
+        /// <returns>New array of the FilesStatistic objects</returns>
+        IStatistic[] GetFilesStatistics();
+
+        /// <summary>
+        /// Get a snapshot of the FilesStatistic objects from this list.
+        /// </summary>
+        /// <returns>New array of the FilesStatistic objects</returns>
+        RoboCopyExitStatus[] GetStatuses();
+
+        /// <summary>
+        /// Get a snapshot of the FilesStatistic objects from this list.
+        /// </summary>
+        /// <returns>New array of the FilesStatistic objects</returns>
+        ISpeedStatistic[] GetSpeedStatistics();
+
+        #endregion
+
+        #region < Events >
+
+        /// <summary> This event fires whenever the List's array is updated. </summary>
+        event NotifyCollectionChangedEventHandler CollectionChanged;
+
+        /// <summary> "Count" PropertyChanged event is raised whenever CollectionChanged is raised. </summary>
+        event PropertyChangedEventHandler PropertyChanged;
+        
+        #endregion
+    }
+
     /// <summary>
     /// Object used to represent results from multiple <see cref="RoboCommand"/>s. <br/>
     /// As <see cref="RoboCopyResults"/> are added to this object, it will update the Totals and Averages accordingly.
@@ -14,7 +84,7 @@ namespace RoboSharp.Results
     /// <remarks>
     /// This object is derived from <see cref="List{T}"/>, where T = <see cref="RoboCopyResults"/>, and implements <see cref="INotifyCollectionChanged"/>
     /// </remarks>
-    public sealed class RoboCopyResultsList : ObservableList<RoboCopyResults>, IDisposable
+    public sealed class RoboCopyResultsList : ObservableList<RoboCopyResults>, IDisposable, IRoboCopyResultsList
     {
         #region < Constructors >
 
@@ -66,19 +136,19 @@ namespace RoboSharp.Results
         #region < Public Properties >
 
         /// <summary> Sum of all DirectoryStatistics objects </summary>
-        public Statistic DirectoriesStatistic => Total_DirStatsField?.Value;
+        public IStatistic DirectoriesStatistic => Total_DirStatsField?.Value;
 
         /// <summary> Sum of all ByteStatistics objects </summary>
-        public Statistic BytesStatistic => Total_ByteStatsField?.Value;
+        public IStatistic BytesStatistic => Total_ByteStatsField?.Value;
 
         /// <summary> Sum of all FileStatistics objects </summary>
-        public Statistic FilesStatistic => Total_FileStatsField?.Value;
+        public IStatistic FilesStatistic => Total_FileStatsField?.Value;
 
         /// <summary> Average of all SpeedStatistics objects </summary>
-        public SpeedStatistic SpeedStatistic => Average_SpeedStatsField?.Value;
+        public ISpeedStatistic SpeedStatistic => Average_SpeedStatsField?.Value;
 
         /// <summary> Sum of all RoboCopyExitStatus objects </summary>
-        public RoboCopyExitStatus Status => ExitStatusSummaryField?.Value;
+        public IRoboCopyCombinedExitStatus Status => ExitStatusSummaryField?.Value;
 
         #endregion
 
@@ -88,7 +158,7 @@ namespace RoboSharp.Results
         /// Get a snapshot of the ByteStatistics objects from this list.
         /// </summary>
         /// <returns>New array of the ByteStatistic objects</returns>
-        public Statistic[] GetByteStatistics()
+        public IStatistic[] GetByteStatistics()
         {
             if (Disposed) return null;
             List<Statistic> tmp = new List<Statistic>{ };
@@ -101,7 +171,7 @@ namespace RoboSharp.Results
         /// Get a snapshot of the DirectoriesStatistic objects from this list.
         /// </summary>
         /// <returns>New array of the DirectoriesStatistic objects</returns>
-        public Statistic[] GetDirectoriesStatistics()
+        public IStatistic[] GetDirectoriesStatistics()
         {
             if (Disposed) return null;
             List<Statistic> tmp = new List<Statistic> { };
@@ -114,7 +184,7 @@ namespace RoboSharp.Results
         /// Get a snapshot of the FilesStatistic objects from this list.
         /// </summary>
         /// <returns>New array of the FilesStatistic objects</returns>
-        public Statistic[] GetFilesStatistics()
+        public IStatistic[] GetFilesStatistics()
         {
             if (Disposed) return null;
             List<Statistic> tmp = new List<Statistic> { };
@@ -140,7 +210,7 @@ namespace RoboSharp.Results
         /// Get a snapshot of the FilesStatistic objects from this list.
         /// </summary>
         /// <returns>New array of the FilesStatistic objects</returns>
-        public SpeedStatistic[] GetSpeedStatistics()
+        public ISpeedStatistic[] GetSpeedStatistics()
         {
             if (Disposed) return null;
             List<SpeedStatistic> tmp = new List<SpeedStatistic> { };

--- a/RoboSharp/Results/RoboCopyResultsList.cs
+++ b/RoboSharp/Results/RoboCopyResultsList.cs
@@ -70,9 +70,6 @@ namespace RoboSharp.Results
 
         /// <summary> This event fires whenever the List's array is updated. </summary>
         event NotifyCollectionChangedEventHandler CollectionChanged;
-
-        /// <summary> "Count" PropertyChanged event is raised whenever CollectionChanged is raised. </summary>
-        event PropertyChangedEventHandler PropertyChanged;
         
         #endregion
     }

--- a/RoboSharp/Results/RoboCopyResultsList.cs
+++ b/RoboSharp/Results/RoboCopyResultsList.cs
@@ -11,7 +11,7 @@ namespace RoboSharp.Results
     /// <summary>
     /// Interface to provide Read-Only access to a <see cref="RoboCopyResultsList"/>
     /// </summary>
-    public interface IRoboCopyResultsList
+    public interface IRoboCopyResultsList : IEnumerable<RoboCopyResults>, INotifyCollectionChanged
     {
         #region < Properties >
 
@@ -65,13 +65,6 @@ namespace RoboSharp.Results
         ISpeedStatistic[] GetSpeedStatistics();
 
         #endregion
-
-        #region < Events >
-
-        /// <summary> This event fires whenever the List's array is updated. </summary>
-        event NotifyCollectionChangedEventHandler CollectionChanged;
-        
-        #endregion
     }
 
     /// <summary>
@@ -81,7 +74,7 @@ namespace RoboSharp.Results
     /// <remarks>
     /// This object is derived from <see cref="List{T}"/>, where T = <see cref="RoboCopyResults"/>, and implements <see cref="INotifyCollectionChanged"/>
     /// </remarks>
-    public sealed class RoboCopyResultsList : ObservableList<RoboCopyResults>, IDisposable, IRoboCopyResultsList
+    public sealed class RoboCopyResultsList : ObservableList<RoboCopyResults>, IRoboCopyResultsList
     {
         #region < Constructors >
 
@@ -124,9 +117,6 @@ namespace RoboSharp.Results
         private Lazy<Statistic> Total_FileStatsField;
         private Lazy<AverageSpeedStatistic> Average_SpeedStatsField;
         private Lazy<RoboCopyCombinedExitStatus> ExitStatusSummaryField;
-        private bool disposedValue;
-        private bool startedDisposing;
-        private bool Disposed => disposedValue || startedDisposing;
 
         #endregion
 
@@ -149,7 +139,7 @@ namespace RoboSharp.Results
 
         #endregion
 
-        #region < Get Array Methods >
+        #region < Get Array Methods ( Public ) >
 
         /// <summary>
         /// Get a snapshot of the ByteStatistics objects from this list.
@@ -157,7 +147,6 @@ namespace RoboSharp.Results
         /// <returns>New array of the ByteStatistic objects</returns>
         public IStatistic[] GetByteStatistics()
         {
-            if (Disposed) return null;
             List<Statistic> tmp = new List<Statistic>{ };
             foreach (RoboCopyResults r in this)
                 tmp.Add(r?.BytesStatistic);
@@ -170,7 +159,6 @@ namespace RoboSharp.Results
         /// <returns>New array of the DirectoriesStatistic objects</returns>
         public IStatistic[] GetDirectoriesStatistics()
         {
-            if (Disposed) return null;
             List<Statistic> tmp = new List<Statistic> { };
             foreach (RoboCopyResults r in this)
                 tmp.Add(r?.DirectoriesStatistic);
@@ -183,7 +171,6 @@ namespace RoboSharp.Results
         /// <returns>New array of the FilesStatistic objects</returns>
         public IStatistic[] GetFilesStatistics()
         {
-            if (Disposed) return null;
             List<Statistic> tmp = new List<Statistic> { };
             foreach (RoboCopyResults r in this)
                 tmp.Add(r?.FilesStatistic);
@@ -196,7 +183,6 @@ namespace RoboSharp.Results
         /// <returns>New array of the FilesStatistic objects</returns>
         public RoboCopyExitStatus[] GetStatuses()
         {
-            if (Disposed) return null;
             List<RoboCopyExitStatus> tmp = new List<RoboCopyExitStatus> { };
             foreach (RoboCopyResults r in this)
                 tmp.Add(r?.Status);
@@ -209,7 +195,6 @@ namespace RoboSharp.Results
         /// <returns>New array of the FilesStatistic objects</returns>
         public ISpeedStatistic[] GetSpeedStatistics()
         {
-            if (Disposed) return null;
             List<SpeedStatistic> tmp = new List<SpeedStatistic> { };
             foreach (RoboCopyResults r in this)
                 tmp.Add(r?.SpeedStatistic);
@@ -224,7 +209,6 @@ namespace RoboSharp.Results
         /// <inheritdoc cref="ObservableList{T}.OnCollectionChanged(NotifyCollectionChangedEventArgs)"/>
         protected override void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
         {
-            if (Disposed) return;
             if (e.Action == NotifyCollectionChangedAction.Move) goto RaiseEvent; // Sorting causes no change in math -> Simply raise the event
 
             //Reset means a drastic change -> Recalculate everything, then goto RaiseEvent
@@ -333,50 +317,6 @@ namespace RoboSharp.Results
             RaiseEvent:
             //Raise the CollectionChanged event
             base.OnCollectionChanged(e);
-        }
-
-        #endregion
-
-        #region < IDisposable >
-
-        private void Dispose(bool disposing)
-        {
-            if (!disposedValue)
-            {
-                startedDisposing = true;
-
-                if (disposing)
-                {
-                    this.Clear();
-                    Total_ByteStatsField = null;
-                    Total_DirStatsField = null;
-                    Total_FileStatsField = null;
-                    Average_SpeedStatsField = null;
-                    ExitStatusSummaryField = null;
-                }
-
-                // TODO: free unmanaged resources (unmanaged objects) and override finalizer
-                // TODO: set large fields to null
-                disposedValue = true;
-            }
-        }
-
-        // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
-        // ~RoboCopyResultsList()
-        // {
-        //     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-        //     Dispose(disposing: false);
-        // }
-
-        /// <summary>
-        /// Clear the list and Set all the calculated statistics objects to null <br/>
-        /// This object uses no 'Unmanaged' resources, so this is not strictly required to be called.
-        /// </summary>
-        public void Dispose()
-        {
-            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
         }
 
         #endregion

--- a/RoboSharp/Results/RoboCopyResultsStatus.cs
+++ b/RoboSharp/Results/RoboCopyResultsStatus.cs
@@ -47,9 +47,34 @@ namespace RoboSharp.Results
     }
 
     /// <summary>
+    /// Read-Only interface for <see cref="RoboCopyCombinedExitStatus"/>
+    /// </summary>
+    public interface IRoboCopyCombinedExitStatus
+    {
+        /// <inheritdoc cref="RoboCopyCombinedExitStatus.WasCancelled"/>
+        bool WasCancelled { get; }
+
+        /// <inheritdoc cref="RoboCopyCombinedExitStatus.AnyNoCopyNoError"/>
+        bool AnyNoCopyNoError { get; }
+
+        /// <inheritdoc cref="RoboCopyCombinedExitStatus.AnyWasCancelled"/>
+        bool AnyWasCancelled { get; }
+
+        /// <inheritdoc cref="RoboCopyCombinedExitStatus.AllSuccessful"/>
+        bool AllSuccessful { get; }
+
+        /// <inheritdoc cref="RoboCopyCombinedExitStatus.AllSuccessful_WithWarnings"/>
+        bool AllSuccessful_WithWarnings { get; }
+
+        /// <summary>This event when the ExitStatus summary has changed </summary>
+        event PropertyChangedEventHandler PropertyChanged;
+
+    }
+
+    /// <summary>
     /// Represents the combination of multiple Exit Statuses
     /// </summary>
-    public sealed class RoboCopyCombinedExitStatus : RoboCopyExitStatus, INotifyPropertyChanged
+    public sealed class RoboCopyCombinedExitStatus : RoboCopyExitStatus, INotifyPropertyChanged, IRoboCopyCombinedExitStatus
     {
         #region < Constructor >
 

--- a/RoboSharp/Results/RoboCopyResultsStatus.cs
+++ b/RoboSharp/Results/RoboCopyResultsStatus.cs
@@ -49,7 +49,7 @@ namespace RoboSharp.Results
     /// <summary>
     /// Read-Only interface for <see cref="RoboCopyCombinedExitStatus"/>
     /// </summary>
-    public interface IRoboCopyCombinedExitStatus
+    public interface IRoboCopyCombinedExitStatus : INotifyPropertyChanged
     {
         /// <inheritdoc cref="RoboCopyCombinedExitStatus.WasCancelled"/>
         bool WasCancelled { get; }
@@ -66,15 +66,12 @@ namespace RoboSharp.Results
         /// <inheritdoc cref="RoboCopyCombinedExitStatus.AllSuccessful_WithWarnings"/>
         bool AllSuccessful_WithWarnings { get; }
 
-        /// <summary>This event when the ExitStatus summary has changed </summary>
-        event PropertyChangedEventHandler PropertyChanged;
-
     }
 
     /// <summary>
     /// Represents the combination of multiple Exit Statuses
     /// </summary>
-    public sealed class RoboCopyCombinedExitStatus : RoboCopyExitStatus, INotifyPropertyChanged, IRoboCopyCombinedExitStatus
+    public sealed class RoboCopyCombinedExitStatus : RoboCopyExitStatus, IRoboCopyCombinedExitStatus
     {
         #region < Constructor >
 

--- a/RoboSharp/Results/SpeedStatistic.cs
+++ b/RoboSharp/Results/SpeedStatistic.cs
@@ -11,10 +11,29 @@ using System.Runtime.CompilerServices;
 namespace RoboSharp.Results
 {
     /// <summary>
+    /// Provide Read-Only access to a SpeedStatistic
+    /// </summary>
+    public interface ISpeedStatistic
+    {
+
+        /// <summary> Average Transfer Rate in Bytes/Second </summary>
+        decimal BytesPerSec { get; }
+
+        /// <summary> Average Transfer Rate in MB/Minute</summary>
+        decimal MegaBytesPerMin { get; }
+
+        /// <inheritdoc cref="SpeedStatistic.PropertyChanged"/>
+        event PropertyChangedEventHandler PropertyChanged;
+
+        /// <inheritdoc cref="SpeedStatistic.ToString"/>
+        string ToString();
+    }
+    
+    /// <summary>
     /// Contains information regarding average Transfer Speed. <br/>
     /// Note: Runs that do not perform any copy operations or that exited prematurely ( <see cref="RoboCopyExitCodes.Cancelled"/> ) will result in a null <see cref="SpeedStatistic"/> object.
     /// </summary>
-    public class SpeedStatistic : INotifyPropertyChanged
+    public class SpeedStatistic : INotifyPropertyChanged, ISpeedStatistic
     {
         #region < Fields, Events, Properties >
 
@@ -27,7 +46,7 @@ namespace RoboSharp.Results
         /// <summary>This event will fire when the value of the SpeedStatistic is updated </summary>
         public event PropertyChangedEventHandler PropertyChanged;
 
-        /// <summary> Average Transfer Rate in Bytes/Second </summary>
+        /// <inheritdoc cref="ISpeedStatistic.BytesPerSec"/>
         public virtual decimal BytesPerSec
         {
             get => BytesPerSecField;
@@ -41,7 +60,7 @@ namespace RoboSharp.Results
             }
         }
 
-        /// <summary> Average Transfer Rate in MB/Minute</summary>
+        /// <inheritdoc cref="ISpeedStatistic.BytesPerSec"/>
         public virtual decimal MegaBytesPerMin
         {
             get => MegaBytesPerMinField;
@@ -114,7 +133,7 @@ namespace RoboSharp.Results
         /// Either a <see cref="SpeedStatistic"/> or a <see cref="AverageSpeedStatistic"/> object. <br/>
         /// If a <see cref="AverageSpeedStatistic"/> is passed into this constructor, it wil be treated as the base <see cref="SpeedStatistic"/> instead.
         /// </param>
-        public AverageSpeedStatistic(SpeedStatistic speedStat) : base()
+        public AverageSpeedStatistic(ISpeedStatistic speedStat) : base()
         {
             Divisor = 1;
             Combined_BytesPerSec = speedStat.BytesPerSec;
@@ -123,11 +142,11 @@ namespace RoboSharp.Results
         }
 
         /// <summary>
-        /// Initialize a new <see cref="AverageSpeedStatistic"/> object using <see cref="AverageSpeedStatistic.Average(IEnumerable{SpeedStatistic})"/>. <br/>
+        /// Initialize a new <see cref="AverageSpeedStatistic"/> object using <see cref="AverageSpeedStatistic.Average(IEnumerable{ISpeedStatistic})"/>. <br/>
         /// </summary>
-        /// <param name="speedStats"><inheritdoc cref="Average(IEnumerable{SpeedStatistic})"/></param>
-        /// <inheritdoc cref="Average(IEnumerable{SpeedStatistic})"/>
-        public AverageSpeedStatistic(IEnumerable<SpeedStatistic> speedStats) : base()
+        /// <param name="speedStats"><inheritdoc cref="Average(IEnumerable{ISpeedStatistic})"/></param>
+        /// <inheritdoc cref="Average(IEnumerable{ISpeedStatistic})"/>
+        public AverageSpeedStatistic(IEnumerable<ISpeedStatistic> speedStats) : base()
         {
             Average(speedStats);
         }
@@ -204,7 +223,7 @@ namespace RoboSharp.Results
 #if !NET40
         [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
 #endif
-        internal void Add(SpeedStatistic stat, bool ForceTreatAsSpeedStat = false)
+        internal void Add(ISpeedStatistic stat, bool ForceTreatAsSpeedStat = false)
         {
             if (stat == null) return;
             bool IsAverageStat = !ForceTreatAsSpeedStat && stat.GetType() == typeof(AverageSpeedStatistic);
@@ -219,12 +238,12 @@ namespace RoboSharp.Results
         /// Add the supplied SpeedStatistic collection to this object.
         /// </summary>
         /// <param name="stats">SpeedStatistic collection to add</param>
-        /// <param name="ForceTreatAsSpeedStat"><inheritdoc cref="Add(SpeedStatistic, bool)"/></param>
-        /// <inheritdoc cref="Add(SpeedStatistic, bool)" path="/remarks"/>
+        /// <param name="ForceTreatAsSpeedStat"><inheritdoc cref="Add(ISpeedStatistic, bool)"/></param>
+        /// <inheritdoc cref="Add(ISpeedStatistic, bool)" path="/remarks"/>
 #if !NET40
         [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
 #endif
-        internal void Add(IEnumerable<SpeedStatistic> stats, bool ForceTreatAsSpeedStat = false)
+        internal void Add(IEnumerable<ISpeedStatistic> stats, bool ForceTreatAsSpeedStat = false)
         {
             foreach (SpeedStatistic stat in stats)
                 Add(stat, ForceTreatAsSpeedStat);
@@ -238,7 +257,7 @@ namespace RoboSharp.Results
         /// Subtract the results of the supplied SpeedStatistic objects from this object.<br/>
         /// </summary>
         /// <param name="stat">Statistics Item to add</param>
-        /// <param name="ForceTreatAsSpeedStat"><inheritdoc cref="Add(SpeedStatistic, bool)"/></param>
+        /// <param name="ForceTreatAsSpeedStat"><inheritdoc cref="Add(ISpeedStatistic, bool)"/></param>
 #if !NET40
         [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
 #endif
@@ -267,7 +286,7 @@ namespace RoboSharp.Results
         /// Subtract the supplied SpeedStatistic collection from this object.
         /// </summary>
         /// <param name="stats">SpeedStatistic collection to subtract</param>
-        /// <param name="ForceTreatAsSpeedStat"><inheritdoc cref="Add(SpeedStatistic, bool)"/></param>
+        /// <param name="ForceTreatAsSpeedStat"><inheritdoc cref="Add(ISpeedStatistic, bool)"/></param>
 #if !NET40
         [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
 #endif
@@ -297,8 +316,8 @@ namespace RoboSharp.Results
         /// Combine the supplied <see cref="SpeedStatistic"/> objects, then get the average.
         /// </summary>
         /// <param name="stat">Stats object</param>
-        /// <inheritdoc cref="Add(SpeedStatistic, bool)" path="/remarks"/>
-        public void Average(SpeedStatistic stat)
+        /// <inheritdoc cref="Add(ISpeedStatistic, bool)" path="/remarks"/>
+        public void Average(ISpeedStatistic stat)
         {
             Add(stat);
             CalculateAverage();
@@ -307,17 +326,17 @@ namespace RoboSharp.Results
         /// <summary>
         /// Combine the supplied <see cref="SpeedStatistic"/> objects, then get the average.
         /// </summary>
-        /// <param name="stats">Collection of <see cref="SpeedStatistic"/> objects</param>
-        /// <inheritdoc cref="Add(SpeedStatistic, bool)" path="/remarks"/>
-        public void Average(IEnumerable<SpeedStatistic> stats)
+        /// <param name="stats">Collection of <see cref="ISpeedStatistic"/> objects</param>
+        /// <inheritdoc cref="Add(ISpeedStatistic, bool)" path="/remarks"/>
+        public void Average(IEnumerable<ISpeedStatistic> stats)
         {
             Add(stats);
             CalculateAverage();
         }
 
         /// <returns>New Statistics Object</returns>
-        /// <inheritdoc cref=" Average(IEnumerable{SpeedStatistic})"/>
-        public static AverageSpeedStatistic GetAverage(IEnumerable<SpeedStatistic> stats)
+        /// <inheritdoc cref=" Average(IEnumerable{ISpeedStatistic})"/>
+        public static AverageSpeedStatistic GetAverage(IEnumerable<ISpeedStatistic> stats)
         {
             AverageSpeedStatistic stat = new AverageSpeedStatistic();
             stat.Average(stats);

--- a/RoboSharp/Results/SpeedStatistic.cs
+++ b/RoboSharp/Results/SpeedStatistic.cs
@@ -13,17 +13,13 @@ namespace RoboSharp.Results
     /// <summary>
     /// Provide Read-Only access to a SpeedStatistic
     /// </summary>
-    public interface ISpeedStatistic
+    public interface ISpeedStatistic : INotifyPropertyChanged
     {
-
         /// <summary> Average Transfer Rate in Bytes/Second </summary>
         decimal BytesPerSec { get; }
 
         /// <summary> Average Transfer Rate in MB/Minute</summary>
         decimal MegaBytesPerMin { get; }
-
-        /// <inheritdoc cref="SpeedStatistic.PropertyChanged"/>
-        event PropertyChangedEventHandler PropertyChanged;
 
         /// <inheritdoc cref="SpeedStatistic.ToString"/>
         string ToString();
@@ -35,13 +31,17 @@ namespace RoboSharp.Results
     /// </summary>
     public class SpeedStatistic : INotifyPropertyChanged, ISpeedStatistic
     {
-        #region < Fields, Events, Properties >
+        #region < Private & Protected Members >
 
         private decimal BytesPerSecField = 0;
         private decimal MegaBytesPerMinField = 0;
 
         /// <summary> This toggle Enables/Disables firing the <see cref="PropertyChanged"/> Event to avoid firing it when doing multiple consecutive changes to the values </summary>
         protected bool EnablePropertyChangeEvent { get; set; } = true;
+
+        #endregion
+
+        #region < Public Properties & Events >
 
         /// <summary>This event will fire when the value of the SpeedStatistic is updated </summary>
         public event PropertyChangedEventHandler PropertyChanged;
@@ -203,7 +203,7 @@ namespace RoboSharp.Results
         // Subtraction is only used when an item is removed from a RoboCopyResultsList 
         // As such, public consumers should typically not require the use of subtract methods 
 
-        #region < ADD >
+        #region < ADD ( internal ) >
 
         /// <summary>
         /// Add the results of the supplied SpeedStatistic objects to this object. <br/>
@@ -251,7 +251,7 @@ namespace RoboSharp.Results
 
         #endregion
 
-        #region < Subtract >
+        #region < Subtract ( internal ) >
 
         /// <summary>
         /// Subtract the results of the supplied SpeedStatistic objects from this object.<br/>
@@ -298,7 +298,7 @@ namespace RoboSharp.Results
 
         #endregion
 
-        #region < AVERAGE >
+        #region < AVERAGE ( public ) >
 
         /// <summary>
         /// Immediately recalculate the BytesPerSec and MegaBytesPerMin values

--- a/RoboSharp/Results/Statistic.cs
+++ b/RoboSharp/Results/Statistic.cs
@@ -92,6 +92,7 @@ namespace RoboSharp.Results
     {
         
         /// <summary> Create a new Statistic object of <see cref="StatType"/> </summary>
+        [Obsolete("Statistic Types require Initialization with a StatType")]
         private Statistic() { }
 
         /// <summary> Create a new Statistic object </summary>

--- a/RoboSharp/Results/Statistic.cs
+++ b/RoboSharp/Results/Statistic.cs
@@ -13,10 +13,8 @@ namespace RoboSharp.Results
     /// <summary>
     /// Provide Read-Only access to a <see cref="Statistic"/> object
     /// </summary>
-    public interface IStatistic
+    public interface IStatistic : INotifyPropertyChanged
     {
-        /// <inheritdoc cref="Statistic.PropertyChanged"/>
-        event PropertyChangedEventHandler PropertyChanged;
 
         #region < Properties >
 
@@ -47,6 +45,31 @@ namespace RoboSharp.Results
 
         /// <summary> Total Extra that exist in the Destination (but are missing from the Source)</summary>
         long Extras { get; }
+
+        #endregion
+
+        #region < Events >
+
+        /// <inheritdoc cref="Statistic.PropertyChanged"/>
+        new event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary> Occurs when the <see cref="Total"/> Property is updated. </summary>
+        event Statistic.StatChangedHandler OnTotalChanged;
+
+        /// <summary> Occurs when the <see cref="Copied"/> Property is updated. </summary>
+        event Statistic.StatChangedHandler OnCopiedChanged;
+
+        /// <summary> Occurs when the <see cref="Skipped"/> Property is updated. </summary>
+        event Statistic.StatChangedHandler OnSkippedChanged;
+
+        /// <summary> Occurs when the <see cref="Mismatch"/> Property is updated. </summary>
+        event Statistic.StatChangedHandler OnMisMatchChanged;
+
+        /// <summary> Occurs when the <see cref="Failed"/> Property is updated. </summary>
+        event Statistic.StatChangedHandler OnFailedChanged;
+
+        /// <summary> Occurs when the <see cref="Extras"/> Property is updated. </summary>
+        event Statistic.StatChangedHandler OnExtrasChanged;
 
         #endregion
 
@@ -88,9 +111,10 @@ namespace RoboSharp.Results
     /// <remarks>
     /// <see cref="RoboCopyResults"/> will not typically raise any events, but this object is used for other items, such as <see cref="ProgressEstimator"/> and <see cref="RoboCopyResultsList"/> to present results whose values may update periodically.
     /// </remarks>
-    public class Statistic : INotifyPropertyChanged, IStatistic
+    public class Statistic : IStatistic
     {
-        
+        #region < Constructors >
+
         /// <summary> Create a new Statistic object of <see cref="StatType"/> </summary>
         [Obsolete("Statistic Types require Initialization with a StatType")]
         private Statistic() { }
@@ -111,6 +135,8 @@ namespace RoboSharp.Results
             /// <summary> Statistics object represents a Size ( number of bytes )</summary>
             Bytes
         }
+
+        #endregion 
 
         #region < Fields >
 
@@ -139,8 +165,8 @@ namespace RoboSharp.Results
         /// </remarks>
         public event PropertyChangedEventHandler PropertyChanged;
 
-        /// <summary>Handles any statistic updates </summary>
-        public delegate void StatChangedHandler(Statistic sender, PropertyChangedEventArgs e);
+        /// <summary>Handles any value changes </summary>
+        public delegate void StatChangedHandler(Statistic sender, StatChangedEventArg e);
 
         /// <summary> Occurs when the <see cref="Total"/> Property is updated. </summary>
         public event StatChangedHandler OnTotalChanged;

--- a/RoboSharp/Results/Statistic.cs
+++ b/RoboSharp/Results/Statistic.cs
@@ -572,7 +572,7 @@ namespace RoboSharp.Results
         /// <param name="stats">Collection of <see cref="Statistic"/> objects</param>
         /// <param name="statType">Create a new Statistic object of this type. If <see cref="StatType.Unknown"/> is specified, adds entire <paramref name="stats"/> collection. </param>
         /// <returns>New Statistics Object</returns>
-        public static Statistic AddStatistics(IEnumerable<IStatistic> stats)
+        public static Statistic AddStatistics(IEnumerable<IStatistic> stats, StatType statType)
         {
             Statistic ret = new Statistic(statType);
             ret.AddStatistic(statType == StatType.Unknown ? stats : stats.Where(s => s.Type == statType) );
@@ -603,7 +603,7 @@ namespace RoboSharp.Results
 
         /// <returns>New Statistics Object</returns>
         /// <inheritdoc cref=" AverageStatistic(IEnumerable{IStatistic})"/>
-        public static Statistic AverageStatistics(IEnumerable<IStatistic> stats)
+        public static Statistic AverageStatistics(IEnumerable<IStatistic> stats, StatType statType)
         {
             Statistic stat = AddStatistics(stats, statType);
             int cnt = statType == StatType.Unknown ? stats.Count() : stats.Count(s => s.Type == statType);

--- a/RoboSharp/Results/Statistic.cs
+++ b/RoboSharp/Results/Statistic.cs
@@ -91,17 +91,14 @@ namespace RoboSharp.Results
     public class Statistic : INotifyPropertyChanged, IStatistic
     {
         
-        /// <summary> Create a new Statistic object of <see cref="StatType.Unknown"/> </summary>
-        public Statistic() { Type = StatType.Unknown; }
+        /// <summary> Create a new Statistic object of <see cref="StatType"/> </summary>
+        private Statistic() { }
 
         /// <summary> Create a new Statistic object </summary>
         public Statistic(StatType type) { Type = type; }
 
         /// <summary> Create a new Statistic object </summary>
         public Statistic(StatType type, string name) { Type = type; Name = name; }
-
-
-        #region < Fields >
 
         /// <summary> Describe the Type of Statistics Object </summary>
         public enum StatType
@@ -111,10 +108,10 @@ namespace RoboSharp.Results
             /// <summary> Statistics object represents count of Files </summary>
             Files,
             /// <summary> Statistics object represents a Size ( number of bytes )</summary>
-            Bytes,
-            /// <summary> Unknown Type - Not specified during construction or Multiple types were combined to generate the result </summary>
-            Unknown
+            Bytes
         }
+
+        #region < Fields >
 
         private string NameField;
         private long TotalField;
@@ -137,7 +134,7 @@ namespace RoboSharp.Results
         /// </summary>
         /// <remarks>
         /// Allows use with both binding to controls and <see cref="ProgressEstimator"/> binding. <br/>
-        /// EventArgs can be passed into <see cref="AddStatistic(StatChangedEventArg)"/> after casting.
+        /// EventArgs can be passed into <see cref="AddStatistic(PropertyChangedEventArgs)"/> after casting.
         /// </remarks>
         public event PropertyChangedEventHandler PropertyChanged;
 
@@ -490,18 +487,19 @@ namespace RoboSharp.Results
         /// <summary>
         /// Add the results of the supplied Statistics object to this Statistics object.
         /// </summary>
-        /// <param name="stats">Statistics Item to add</param>
+        /// <param name="stat">Statistics Item to add</param>
 #if !NET40
         [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
 #endif
-        public void AddStatistic(IStatistic stats)
+        public void AddStatistic(IStatistic stat)
         {
-            Total += stats?.Total ?? 0;
-            Copied += stats?.Copied ?? 0;
-            Extras += stats?.Extras ?? 0;
-            Failed += stats?.Failed ?? 0;
-            Mismatch += stats?.Mismatch ?? 0;
-            Skipped += stats?.Skipped ?? 0;
+            if (stat.Type != this.Type) return;
+            Total += stat?.Total ?? 0;
+            Copied += stat?.Copied ?? 0;
+            Extras += stat?.Extras ?? 0;
+            Failed += stat?.Failed ?? 0;
+            Mismatch += stat?.Mismatch ?? 0;
+            Skipped += stat?.Skipped ?? 0;
         }
 
         
@@ -570,12 +568,12 @@ namespace RoboSharp.Results
         /// Combine the results of the supplied statistics objects of the specified type.
         /// </summary>
         /// <param name="stats">Collection of <see cref="Statistic"/> objects</param>
-        /// <param name="statType">Create a new Statistic object of this type. If <see cref="StatType.Unknown"/> is specified, adds entire <paramref name="stats"/> collection. </param>
+        /// <param name="statType">Create a new Statistic object of this type.</param>
         /// <returns>New Statistics Object</returns>
         public static Statistic AddStatistics(IEnumerable<IStatistic> stats, StatType statType)
         {
             Statistic ret = new Statistic(statType);
-            ret.AddStatistic(statType == StatType.Unknown ? stats : stats.Where(s => s.Type == statType) );
+            ret.AddStatistic(stats.Where(s => s.Type == statType) );
             return ret;
         }
 
@@ -606,7 +604,7 @@ namespace RoboSharp.Results
         public static Statistic AverageStatistics(IEnumerable<IStatistic> stats, StatType statType)
         {
             Statistic stat = AddStatistics(stats, statType);
-            int cnt = statType == StatType.Unknown ? stats.Count() : stats.Count(s => s.Type == statType);
+            int cnt = stats.Count(s => s.Type == statType);
             if (cnt > 1)
             {
                 stat.Total /= cnt;

--- a/RoboSharp/Results/Statistic.cs
+++ b/RoboSharp/Results/Statistic.cs
@@ -11,12 +11,84 @@ using System.Runtime.CompilerServices;
 namespace RoboSharp.Results
 {
     /// <summary>
+    /// Provide Read-Only access to a <see cref="Statistic"/> object
+    /// </summary>
+    public interface IStatistic
+    {
+        /// <inheritdoc cref="Statistic.PropertyChanged"/>
+        event PropertyChangedEventHandler PropertyChanged;
+
+        #region < Properties >
+
+        /// <summary>
+        /// Name of the Statistics Object
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// <inheritdoc cref="Statistic.StatType"/>
+        /// </summary>
+        Statistic.StatType Type { get; }
+
+        /// <summary> Total Scanned during the run</summary>
+        long Total { get; }
+
+        /// <summary> Total Copied </summary>
+        long Copied { get; }
+
+        /// <summary> Total Skipped </summary>
+        long Skipped { get; }
+
+        /// <summary>  </summary>
+        long Mismatch { get; }
+
+        /// <summary> Total that failed to copy or move </summary>
+        long Failed { get; }
+
+        /// <summary> Total Extra that exist in the Destination (but are missing from the Source)</summary>
+        long Extras { get; }
+
+        #endregion
+
+        #region < ToString Methods >
+
+        /// <inheritdoc cref="SpeedStatistic.ToString"/>
+        string ToString();
+
+        /// <inheritdoc cref="Statistic.ToString(bool, bool, string, bool)"/>
+        string ToString(bool IncludeType, bool IncludePrefix, string Delimiter, bool DelimiterAfterType=false);
+
+        /// <inheritdoc cref="Statistic.ToString_Type()"/>
+        string ToString_Type();
+
+        /// <inheritdoc cref="Statistic.ToString_Total(bool, bool)"/>
+        string ToString_Total(bool IncludeType = false, bool IncludePrefix = true);
+
+        /// <inheritdoc cref="Statistic.ToString_Copied"/>
+        string ToString_Copied(bool IncludeType = false, bool IncludePrefix = true);
+
+        /// <inheritdoc cref="Statistic.ToString_Extras"/>
+        string ToString_Extras(bool IncludeType = false, bool IncludePrefix = true);
+
+        /// <inheritdoc cref="Statistic.ToString_Failed"/>
+        string ToString_Failed(bool IncludeType = false, bool IncludePrefix = true);
+
+        /// <inheritdoc cref="Statistic.ToString_Mismatch"/>
+        string ToString_Mismatch(bool IncludeType = false, bool IncludePrefix = true);
+
+        /// <inheritdoc cref="Statistic.ToString_Skipped"/>
+        string ToString_Skipped(bool IncludeType = false, bool IncludePrefix = true);
+        
+        #endregion
+    }
+
+    /// <summary>
     /// Information about number of items Copied, Skipped, Failed, etc.
     /// </summary>
     /// <remarks>
     /// <see cref="RoboCopyResults"/> will not typically raise any events, but this object is used for other items, such as <see cref="ProgressEstimator"/> and <see cref="RoboCopyResultsList"/> to present results whose values may update periodically.
     /// </remarks>
-    public class Statistic : INotifyPropertyChanged
+    public class Statistic : INotifyPropertyChanged, IStatistic
     {
         
         /// <summary> Create a new Statistic object of <see cref="StatType.Unknown"/> </summary>
@@ -118,7 +190,7 @@ namespace RoboSharp.Results
         /// </summary>
         public StatType Type { get; }
 
-        /// <summary> Total Scanned during the run</summary>
+        /// <inheritdoc cref="IStatistic.Total"/>
         public long Total { 
             get => TotalField;
             internal set
@@ -136,7 +208,7 @@ namespace RoboSharp.Results
             }
         }
 
-        /// <summary> Total Copied </summary>
+        /// <inheritdoc cref="IStatistic.Copied"/>
         public long Copied { 
             get => CopiedField;
             internal set
@@ -154,7 +226,7 @@ namespace RoboSharp.Results
             }
         }
 
-        /// <summary> Total Skipped </summary>
+        /// <inheritdoc cref="IStatistic.Skipped"/>
         public long Skipped { 
             get => SkippedField;
             internal set
@@ -172,7 +244,7 @@ namespace RoboSharp.Results
             }
         }
 
-        /// <summary>  </summary>
+        /// <inheritdoc cref="IStatistic.Mismatch"/>
         public long Mismatch { 
             get => MismatchField;
             internal set
@@ -190,7 +262,7 @@ namespace RoboSharp.Results
             }
         }
 
-        /// <summary> Total that failed to copy or move </summary>
+        /// <inheritdoc cref="IStatistic.Failed"/>
         public long Failed { 
             get => FailedField;
             internal set
@@ -208,7 +280,7 @@ namespace RoboSharp.Results
             }
         }
 
-        /// <summary> Total Extra that exist in the Destination (but are missing from the Source)</summary>
+        /// <inheritdoc cref="IStatistic.Extras"/>
         public long Extras { 
             get => ExtrasField;
             internal set
@@ -422,7 +494,7 @@ namespace RoboSharp.Results
 #if !NET40
         [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
 #endif
-        public void AddStatistic(Statistic stats)
+        public void AddStatistic(IStatistic stats)
         {
             Total += stats?.Total ?? 0;
             Copied += stats?.Copied ?? 0;
@@ -435,8 +507,8 @@ namespace RoboSharp.Results
         
         #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         /// <param name="enablePropertyChangedEvent"><inheritdoc cref="EnablePropertyChangeEvent" path="*"/></param>
-        /// <inheritdoc cref="AddStatistic(Statistic)"/>        
-        internal void AddStatistic(Statistic stats, bool enablePropertyChangedEvent)
+        /// <inheritdoc cref="AddStatistic(IStatistic)"/>        
+        internal void AddStatistic(IStatistic stats, bool enablePropertyChangedEvent)
         {
             EnablePropertyChangeEvent = enablePropertyChangedEvent;
             AddStatistic(stats);
@@ -450,7 +522,7 @@ namespace RoboSharp.Results
         /// Add the results of the supplied Statistics objects to this Statistics object.
         /// </summary>
         /// <param name="stats">Statistics Item to add</param>
-        public void AddStatistic(IEnumerable<Statistic> stats)
+        public void AddStatistic(IEnumerable<IStatistic> stats)
         {
             foreach (Statistic stat in stats)
             {
@@ -500,7 +572,7 @@ namespace RoboSharp.Results
         /// <param name="stats">Collection of <see cref="Statistic"/> objects</param>
         /// <param name="statType">Create a new Statistic object of this type. If <see cref="StatType.Unknown"/> is specified, adds entire <paramref name="stats"/> collection. </param>
         /// <returns>New Statistics Object</returns>
-        public static Statistic AddStatistics(IEnumerable<Statistic> stats, StatType statType)
+        public static Statistic AddStatistics(IEnumerable<IStatistic> stats)
         {
             Statistic ret = new Statistic(statType);
             ret.AddStatistic(statType == StatType.Unknown ? stats : stats.Where(s => s.Type == statType) );
@@ -516,7 +588,7 @@ namespace RoboSharp.Results
         /// Combine the supplied <see cref="Statistic"/> objects, then get the average.
         /// </summary>
         /// <param name="stats">Array of Stats objects</param>
-        public void AverageStatistic(IEnumerable<Statistic> stats)
+        public void AverageStatistic(IEnumerable<IStatistic> stats)
         {
             this.AddStatistic(stats);
             int cnt = stats.Count() + 1;
@@ -530,9 +602,8 @@ namespace RoboSharp.Results
         }
 
         /// <returns>New Statistics Object</returns>
-        /// <inheritdoc cref=" AverageStatistic(IEnumerable{Statistic})"/>
-        /// <inheritdoc cref="AddStatistics(IEnumerable{Statistic}, StatType)"/>
-        public static Statistic AverageStatistics(IEnumerable<Statistic> stats, StatType statType)
+        /// <inheritdoc cref=" AverageStatistic(IEnumerable{IStatistic})"/>
+        public static Statistic AverageStatistics(IEnumerable<IStatistic> stats)
         {
             Statistic stat = AddStatistics(stats, statType);
             int cnt = statType == StatType.Unknown ? stats.Count() : stats.Count(s => s.Type == statType);
@@ -559,7 +630,7 @@ namespace RoboSharp.Results
 #if !NET40
         [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
 #endif
-        public void Subtract(Statistic stat)
+        public void Subtract(IStatistic stat)
         {
             Copied -= stat?.Copied ?? 0;
             Extras -= stat?.Extras ?? 0;
@@ -571,8 +642,8 @@ namespace RoboSharp.Results
 
         #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         /// <param name="enablePropertyChangedEvent"><inheritdoc cref="EnablePropertyChangeEvent" path="*"/></param>
-        /// <inheritdoc cref="Subtract(Statistic)"/>        
-        internal void Subtract(Statistic stats, bool enablePropertyChangedEvent)
+        /// <inheritdoc cref="Subtract(IStatistic)"/>        
+        internal void Subtract(IStatistic stats, bool enablePropertyChangedEvent)
         {
             EnablePropertyChangeEvent = enablePropertyChangedEvent;
             Subtract(stats);
@@ -584,7 +655,7 @@ namespace RoboSharp.Results
         /// Add the results of the supplied Statistics objects to this Statistics object.
         /// </summary>
         /// <param name="stats">Statistics Item to add</param>
-        public void Subtract(IEnumerable<Statistic> stats)
+        public void Subtract(IEnumerable<IStatistic> stats)
         {
             foreach (Statistic stat in stats)
             {

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -112,7 +112,7 @@ namespace RoboSharp
         /// <remarks>
         /// A new <see cref="Results.ProgressEstimator"/> object is created every time the <see cref="Start"/> method is called, but will not be created until called for the first time. 
         /// </remarks>
-        public Results.IProgressEstimator ProgressEstimator { get; private set; }
+        public Results.ProgressEstimator ProgressEstimator { get; private set; }
 
         /// <summary>
         /// Value indicating if the process should be killed when the <see cref="Dispose()"/> method is called.<br/>

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -112,13 +112,13 @@ namespace RoboSharp
         /// <remarks>
         /// A new <see cref="Results.ProgressEstimator"/> object is created every time the <see cref="Start"/> method is called, but will not be created until called for the first time. 
         /// </remarks>
-        public Results.ProgressEstimator ProgressEstimator { get; private set; }
+        public Results.IProgressEstimator ProgressEstimator { get; private set; }
 
         /// <summary>
-        /// Value indicating if the process should be killed when the <see cref="Dispose()"/> method is called. <br/>
-        /// For example, if the RoboCopy process should exit when the program exits, this should be set to TRUE.
+        /// Value indicating if the process should be killed when the <see cref="Dispose()"/> method is called.<br/>
+        /// For example, if the RoboCopy process should exit when the program exits, this should be set to TRUE (default).
         /// </summary>
-        public bool StopIfDisposing { get; set; }
+        public bool StopIfDisposing { get; set; } = true;
 
         #endregion Public Vars
 
@@ -391,7 +391,7 @@ namespace RoboSharp
 
                 //Raise EstimatorCreatedEvent to alert consumers that the Estimator can now be bound to
                 ProgressEstimator = resultsBuilder.Estimator;
-                OnProgressEstimatorCreated?.Invoke(this, new Results.ProgressEstimatorCreatedEventArgs(ProgressEstimator));
+                OnProgressEstimatorCreated?.Invoke(this, new Results.ProgressEstimatorCreatedEventArgs(resultsBuilder.Estimator));
 
                 process = new Process();
 
@@ -532,6 +532,15 @@ namespace RoboSharp
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        /// Finalizer -> Cleans up resources when garbage collected
+        /// </summary>
+        ~RoboCommand()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: false);
+        }
+
         /// <summary>IDisposable Implementation</summary>
         protected virtual void Dispose(bool disposing)
         {
@@ -547,6 +556,9 @@ namespace RoboSharp
             {
                 Stop();
             }
+                
+            //Release any hooks to the process, but allow it to continue running
+            process?.Dispose();
 
             disposed = true;
         }


### PR DESCRIPTION
When I added in the StatType enum, I forgot to specify a StatType for the RoboCopyResultsList stat objects. 
This fixes that by introducing a new parameter to the static methods. 

Name property will also now raise NotifyPropertyChanged event, and `public void AddStatistic(PropertyChangedEventArgs eventArgs)` have been adjusted accordingly. 

Two issues / concerns remain:

 - `public void AddStatistic(Statistic stats)` allows adding any two statistics objects together. Obviously this means that you can add a FILE stat and a DIR stat. This library won't be doing that, but should this method only allow adding of like types?
     - My idea is that stat with type `unknown ` can add any stat to it, but File/Byte/Dir types will ignore dissimilar types.
     - OR, allow any stat object to add to another Stat object, but if types are dissimilar update the type to `unkown` / throw error. 

Same concern exists for public Subtract method.