### PR TITLE
Fix RoboCommand Start producing Task<Task>

### DIFF
--- a/RoboSharp.BackupApp/JobHistoryExpander_SingleJob.xaml.cs
+++ b/RoboSharp.BackupApp/JobHistoryExpander_SingleJob.xaml.cs
@@ -76,13 +76,14 @@ namespace RoboSharp.BackupApp
             ByteStat = list.BytesStatistic;
             DirStat = list.DirectoriesStatistic;
             FileStat = list.FilesStatistic;
+            
+            IsResultsListBound = true;
+
+            ShowResultsListSummary(null, new System.ComponentModel.PropertyChangedEventArgs(""));
             DirectoriesStatistic_PropertyChanged(null, null);
             FilesStatistic_PropertyChanged(null, null);
             BytesStatistic_PropertyChanged(null, null);
             
-            
-            IsResultsListBound = true;
-
             ////Trigger List Update
             DirStat.PropertyChanged += ShowResultsListSummary;
             FileStat.PropertyChanged += ShowResultsListSummary;

--- a/RoboSharp.BackupApp/JobHistoryExpander_SingleJob.xaml.cs
+++ b/RoboSharp.BackupApp/JobHistoryExpander_SingleJob.xaml.cs
@@ -121,7 +121,7 @@ namespace RoboSharp.BackupApp
                 () =>
                 {
                     lbl.Content = stat?.ToString(false, true, "\n", false) ?? "";
-                    if (!IsResultsListBound) ShowSelectedJobSummary(); else ShowResultsListSummary(null, null);
+                    if (!IsResultsListBound) ShowSelectedJobSummary();
                 });
         }
 
@@ -153,7 +153,7 @@ namespace RoboSharp.BackupApp
         /// </summary>
         private void ShowResultsListSummary(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            if (e == null || e.PropertyName != "Total") return;
+            if (e == null || (e.PropertyName != "" && e.PropertyName != "Total")) return;
             string NL = Environment.NewLine;
             if (ResultsList == null || ResultsList.Count == 0)
             {

--- a/RoboSharp/ExtensionMethods.cs
+++ b/RoboSharp/ExtensionMethods.cs
@@ -144,7 +144,6 @@ namespace System.Threading
 
         /// <summary>
         /// Use await Task.Delay to sleep the thread. <br/>
-        /// Supplied token is used to create a LinkedToken that can cancel the sleep at any point.
         /// </summary>
         /// <returns>True if timer has expired (full duration slep), otherwise false.</returns>
         /// <param name="millisecondsTimeout">Number of milliseconds to wait"/></param>

--- a/RoboSharp/Results/ProgressEstimator.cs
+++ b/RoboSharp/Results/ProgressEstimator.cs
@@ -127,7 +127,10 @@ namespace RoboSharp.Results
         /// <summary>
         /// Repackage the statistics into a new <see cref="RoboCopyResults"/> object
         /// </summary>
-        /// <remarks>Used by ResultsBuilder as starting point for the results.</remarks>
+        /// <remarks>
+        /// Used by ResultsBuilder as starting point for the results. 
+        /// Should not be used anywhere else, as it kills the worker thread that calculates the Statistics objects.
+        /// </remarks>
         /// <returns></returns>
         internal RoboCopyResults GetResults()
         {

--- a/RoboSharp/Results/ProgressEstimator.cs
+++ b/RoboSharp/Results/ProgressEstimator.cs
@@ -4,6 +4,8 @@ using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using RoboSharp.Interfaces;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace RoboSharp.Results
 {
@@ -35,7 +37,8 @@ namespace RoboSharp.Results
             ByteStatsField = new Statistic(Statistic.StatType.Bytes, "Byte Stats Estimate");
 
             BytesToAdd = new System.Collections.Concurrent.ConcurrentQueue<Tuple<ProcessedFileInfo, WhereToAdd>>();
-            ByteCalcRequested = new Lazy<bool>(() => { DeQueueByteCalc(); return true; });
+            DirsToAdd = new System.Collections.Concurrent.ConcurrentQueue<WhereToAdd>();
+            CalculationTask = StartCalculationTask(out CalculationTaskCancelSource);
         }
 
         #endregion
@@ -51,8 +54,11 @@ namespace RoboSharp.Results
         private readonly Statistic FileStatsField;
         private readonly Statistic ByteStatsField;
 
-        private readonly Lazy<bool> ByteCalcRequested; //Byte Calc can be very large, so calculation only occurs after first request. Dirs and FileCounts are incremented 1 at a time, so no optimization is needed.
+        private readonly Task CalculationTask;
+        private readonly CancellationTokenSource CalculationTaskCancelSource;
         private readonly System.Collections.Concurrent.ConcurrentQueue<Tuple<ProcessedFileInfo, WhereToAdd>> BytesToAdd;    //Store Files in queue for calculation since bytes can be large
+        private readonly System.Collections.Concurrent.ConcurrentQueue<WhereToAdd> DirsToAdd;
+
         internal enum WhereToAdd { Copied, Skipped, Extra, MisMatch, Failed }
 
         internal ProcessedFileInfo CurrentDir;
@@ -78,7 +84,7 @@ namespace RoboSharp.Results
         /// Estimate of current number of bytes processed while the job is still running. <br/>
         /// Estimate is provided by parsing of the LogLines produces by RoboCopy.
         /// </summary>
-        public IStatistic BytesStatistic => ByteCalcRequested.Value ? ByteStatsField : ByteStatsField;
+        public IStatistic BytesStatistic => ByteStatsField;
 
         RoboCopyExitStatus IResults.Status => new RoboCopyExitStatus((int)GetExitCode());
 
@@ -128,6 +134,8 @@ namespace RoboSharp.Results
             //ResultsBuilder calls this at end of run:
             // - if copy operation wasn't completed, register it as failed instead.
             // - if file was to be marked as 'skipped', then register it as skipped.
+            CalculationTaskCancelSource.Cancel();
+            CalculationTask.Wait();
             if (CopyOpStarted && CurrentFile != null)
             {
                 FileStatsField.Failed++;
@@ -151,31 +159,26 @@ namespace RoboSharp.Results
 
         #endregion
 
-        #region < Counting Methods ( Internal ) >
+        #region < Queue Files and Dirs (Internal) >
 
         /// <summary>Increment <see cref="DirStatField"/></summary>
         internal void AddDir(ProcessedFileInfo currentDir, bool CopyOperation)
         {
             CurrentDir = currentDir;
-            DirStatField.Total++;
-            if (currentDir.FileClass == Config.LogParsing_ExistingDir) { DirStatField.Skipped++; }
-            else if (currentDir.FileClass == Config.LogParsing_NewDir) { DirStatField.Copied++; }
-            else if (currentDir.FileClass == Config.LogParsing_ExtraDir) DirStatField.Extras++;
+            if (currentDir.FileClass == Config.LogParsing_ExistingDir) { DirsToAdd.Enqueue(WhereToAdd.Skipped); }
+            else if (currentDir.FileClass == Config.LogParsing_NewDir) { DirsToAdd.Enqueue(WhereToAdd.Copied); }
+            else if (currentDir.FileClass == Config.LogParsing_ExtraDir) { DirsToAdd.Enqueue(WhereToAdd.Extra); }
             else
             {
 
             }
         }
 
-        #region < AddFile >
-
         /// <summary>Increment <see cref="FileStatsField"/></summary>
         internal void AddFile(ProcessedFileInfo currentFile, bool CopyOperation)
         {
-            FileStatsField.Total++;
             if (SkippingFile)
             {
-                FileStatsField.Skipped++;
                 QueueByteCalc(currentFile, WhereToAdd.Skipped);
             }
 
@@ -186,25 +189,21 @@ namespace RoboSharp.Results
             // EXTRA FILES
             if (currentFile.FileClass == Config.LogParsing_ExtraFile)
             {
-                FileStatsField.Extras++;
                 QueueByteCalc(currentFile, WhereToAdd.Extra);
             }
             //MisMatch
             else if (currentFile.FileClass == Config.LogParsing_MismatchFile)
             {
-                FileStatsField.Mismatch++;
                 QueueByteCalc(currentFile, WhereToAdd.MisMatch);
             }
             //Failed Files
             else if (currentFile.FileClass == Config.LogParsing_FailedFile)
             {
-                FileStatsField.Failed++;
                 QueueByteCalc(currentFile, WhereToAdd.Failed);
             }
             //Identical Files
             else if (currentFile.FileClass == Config.LogParsing_SameFile)
             {
-                FileStatsField.Skipped++;
                 QueueByteCalc(currentFile, WhereToAdd.Skipped);
                 CurrentFile = null;
             }
@@ -218,94 +217,34 @@ namespace RoboSharp.Results
                     //Special handling for 0kb files -> They won't get Progress update, but will be created
                     if (currentFile.Size == 0)
                     {
-                        FileStatsField.Copied++;
+                        QueueByteCalc(currentFile, WhereToAdd.Copied);
                         SkippingFile = false;
                     }
                     else if (!CopyOperation)
                     {
-                        FileStatsField.Copied++;
                         QueueByteCalc(currentFile, WhereToAdd.Copied);
                     }
                 }
                 else if (currentFile.FileClass == Config.LogParsing_OlderFile)
                 {
                     if (!CopyOperation && !command.SelectionOptions.ExcludeNewer)
-                    {
-                        FileStatsField.Copied++;
                         QueueByteCalc(currentFile, WhereToAdd.Copied);
-                    }
                 }
                 else if (currentFile.FileClass == Config.LogParsing_NewerFile)
                 {
                     if (!CopyOperation && !command.SelectionOptions.ExcludeOlder)
-                    {
-                        FileStatsField.Copied++;
                         QueueByteCalc(currentFile, WhereToAdd.Copied);
-                    }
                 }
             }
         }
-
-        #region < Byte Stat Optimization >
 
         /// <summary>
         /// Stage / perform the calculation for the ByteStatistic
         /// </summary>
         private void QueueByteCalc(ProcessedFileInfo file, WhereToAdd whereTo)
         {
-            if (ByteCalcRequested.IsValueCreated)
-            {
-                if (!BytesToAdd.IsEmpty) DeQueueByteCalc(); // Process the queue first
-                CalculateByteStat(file, whereTo);
-            }
-            else
-                BytesToAdd.Enqueue(new Tuple<ProcessedFileInfo, WhereToAdd>(file, whereTo));
+            BytesToAdd.Enqueue(new Tuple<ProcessedFileInfo, WhereToAdd>(file, whereTo));
         }
-
-        /// <summary>
-        /// Allows Defering calculation of DirStat until the Lazy Object is requested
-        /// </summary>
-        private void DeQueueByteCalc()
-        {
-            while (!BytesToAdd.IsEmpty)
-            {
-                if (BytesToAdd.TryDequeue(out var TP))
-                {
-                    ByteStatsField.EnablePropertyChangeEvent = BytesToAdd.IsEmpty; //Disable PropertyChangeEvent until last item in list
-                    CalculateByteStat(TP.Item1, TP.Item2);
-                }
-            }
-        }
-
-        private void CalculateByteStat(ProcessedFileInfo currentFile, WhereToAdd whereTo)
-        {
-            ByteStatsField.Total += currentFile.Size;
-
-            switch (whereTo)
-            {
-                case WhereToAdd.Copied:
-                    ByteStatsField.Copied += currentFile.Size;
-                    break;
-
-                case WhereToAdd.Skipped:
-                    ByteStatsField.Skipped += currentFile.Size;
-                    break;
-
-                case WhereToAdd.Extra:
-                    ByteStatsField.Extras += currentFile.Size;
-                    break;
-
-                case WhereToAdd.MisMatch:
-                    ByteStatsField.Mismatch += currentFile.Size;
-                    break;
-
-                case WhereToAdd.Failed:
-                    ByteStatsField.Failed += currentFile.Size;
-                    break;
-            }
-        }
-
-        #endregion
 
         /// <summary>Catch start copy progress of large files</summary>
         internal void SetCopyOpStarted()
@@ -319,12 +258,136 @@ namespace RoboSharp.Results
         {
             SkippingFile = false;
             CopyOpStarted = false;
-            FileStatsField.Copied++;
             QueueByteCalc(currentFile, WhereToAdd.Copied);
             CurrentFile = null;
         }
 
         #endregion
+
+        #region < Calculation Task >
+
+        private Task StartCalculationTask(out CancellationTokenSource CancelSource)
+        {
+            
+            CancelSource = new CancellationTokenSource();
+            var CS = CancelSource;
+            return Task.Factory.StartNew(async () => 
+                {
+                    DateTime LastUpdate = DateTime.Now;
+                    TimeSpan UpdatePeriod = new TimeSpan(0, 0, 0, 0, 125);
+                    bool DirAdded = false;
+                    bool FileAdded = false;
+
+                    var tmpDir = new Statistic(type: Statistic.StatType.Directories);
+                    var tmpFile = new Statistic(type: Statistic.StatType.Files);
+                    var tmpByte = new Statistic(type: Statistic.StatType.Bytes);
+
+                    while (!CS.IsCancellationRequested)
+                    {
+                        DirAdded = ClearOutDirs(LastUpdate, UpdatePeriod, tmpDir);
+                        FileAdded = ClearOutBytes(LastUpdate, UpdatePeriod, tmpByte, tmpFile);
+
+                        if (DateTime.Now.Subtract(LastUpdate) >= UpdatePeriod && FileAdded | DirAdded)
+                        {
+                            PushUpdate(ref DirAdded, ref FileAdded, tmpDir, tmpByte, tmpFile);
+                            LastUpdate = DateTime.Now;
+                        }
+                        else
+                            await ThreadEx.CancellableSleep(15, CS.Token);
+                    }
+                    await Task.Delay(250); // Provide 250ms for bags to fill up
+                    UpdatePeriod = new TimeSpan(days: 5, 0, 0, 0); //Set excessively long timespan to stay in loop
+                    while (!BytesToAdd.IsEmpty || !DirsToAdd.IsEmpty)   //Clean out the bags
+                    {
+                        DirAdded = ClearOutDirs(LastUpdate, UpdatePeriod, tmpDir);
+                        FileAdded = ClearOutBytes(LastUpdate, UpdatePeriod, tmpByte, tmpFile);
+                        await Task.Delay(15);
+                    }
+                    PushUpdate(ref DirAdded, ref FileAdded, tmpDir, tmpByte, tmpFile);
+
+                }, CancelSource.Token, TaskCreationOptions.LongRunning, PriorityScheduler.BelowNormal).Unwrap();
+            
+        }
+
+        private bool ClearOutDirs(DateTime LastUpdate, TimeSpan UpdatePeriod, Statistic tmpDir)
+        {
+            //Calculate Dirs
+            bool DirAdded = false;
+            while (DateTime.Now.Subtract(LastUpdate) < UpdatePeriod && !DirsToAdd.IsEmpty)
+            {
+                if (DirsToAdd.TryDequeue(out var whereToAdd))
+                {
+                    tmpDir.Total++;
+                    switch (whereToAdd)
+                    {
+                        case WhereToAdd.Copied: tmpDir.Copied++; break;
+                        case WhereToAdd.Extra: tmpDir.Extras++; break;
+                        case WhereToAdd.Failed: tmpDir.Failed++; break;
+                        case WhereToAdd.MisMatch: tmpDir.Mismatch++; break;
+                        case WhereToAdd.Skipped: tmpDir.Skipped++; break;
+                    }
+                    DirAdded = true;
+                }
+            }
+            return DirAdded;
+        }
+
+        private bool ClearOutBytes(DateTime LastUpdate, TimeSpan UpdatePeriod, Statistic tmpByte, Statistic tmpFile)
+        {
+            //Calculate Files and Bytes
+            bool FileAdded = false;
+            while (DateTime.Now.Subtract(LastUpdate) < UpdatePeriod && !BytesToAdd.IsEmpty)
+            {
+                if (BytesToAdd.TryDequeue(out var tuple))
+                {
+                    tmpFile.Total++;
+                    tmpByte.Total += tuple.Item1.Size;
+                    switch (tuple.Item2)
+                    {
+                        case WhereToAdd.Copied:
+                            tmpFile.Copied++;
+                            tmpByte.Copied += tuple.Item1.Size;
+                            break;
+                        case WhereToAdd.Extra:
+                            tmpFile.Extras++;
+                            tmpByte.Extras += tuple.Item1.Size;
+                            break;
+                        case WhereToAdd.Failed:
+                            tmpFile.Failed++;
+                            tmpByte.Failed += tuple.Item1.Size;
+                            break;
+                        case WhereToAdd.MisMatch:
+                            tmpFile.Mismatch++;
+                            tmpByte.Mismatch += tuple.Item1.Size;
+                            break;
+                        case WhereToAdd.Skipped:
+                            tmpFile.Skipped++;
+                            tmpByte.Skipped += tuple.Item1.Size;
+                            break;
+                    }
+                    FileAdded = true;
+                }
+            }
+            return FileAdded;
+        }
+
+        private void PushUpdate(ref bool DirAdded,ref bool FileAdded, Statistic tmpDir, Statistic tmpByte, Statistic tmpFile)
+        {
+            if (DirAdded)
+            {
+                DirStatField.AddStatistic(tmpDir);
+                tmpDir.Reset();
+                DirAdded = false;
+            }
+            if (FileAdded)
+            {
+                FileStatsField.AddStatistic(tmpFile);
+                ByteStatsField.AddStatistic(tmpByte);
+                tmpByte.Reset();
+                tmpFile.Reset();
+                FileAdded = false;
+            }
+        }
 
         #endregion
 

--- a/RoboSharp/Results/RoboQueueProgressEstimator.cs
+++ b/RoboSharp/Results/RoboQueueProgressEstimator.cs
@@ -129,19 +129,19 @@ namespace RoboSharp.Results
             CancelSource = new CancellationTokenSource();
             var CS = CancelSource; //Compiler required abstracting since this is a CancelSource is marked as ref
 
-            TaskRef = Task.Factory.StartNew(() =>
+            TaskRef = Task.Factory.StartNew( async () =>
             {
                 Statistic tmp = new Statistic(type: StatToAddTo.Type);
                 while (!CS.IsCancellationRequested)
                 {
                     BagClearOut(tmp, StatToAddTo, EventBag);
-                    Thread.Sleep(UpdatePeriodInMilliSecond);
+                    await Task.Delay(UpdatePeriodInMilliSecond);
                 }
-                Thread.Sleep(250); //Sleep for a bit to let the bag fill up
+                await Task.Delay(250); //Sleep for a bit to let the bag fill up
                 //After cancellation is requested, ensure the bag is emptied
                 BagClearOut(tmp, StatToAddTo, EventBag);
 
-            }, CS.Token, TaskCreationOptions.LongRunning, PriorityScheduler.BelowNormal);
+            }, CS.Token, TaskCreationOptions.LongRunning, PriorityScheduler.BelowNormal).Unwrap();
             
             return TaskRef;
         }

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -444,7 +444,7 @@ namespace RoboSharp
                process.BeginOutputReadLine();
                process.BeginErrorReadLine();
                await process.WaitForExitAsync(); //Wait asynchronously for process to exit
-                results = resultsBuilder.BuildResults(process?.ExitCode ?? -1);
+               results = resultsBuilder.BuildResults(process?.ExitCode ?? -1);
                Debugger.Instance.DebugMessage("RoboCopy process exited.");
            }, cancellationToken, TaskCreationOptions.LongRunning, PriorityScheduler.BelowNormal).Unwrap();
 

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -283,7 +283,7 @@ namespace RoboSharp
         }
 
 
-#if NET45 || NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP3_1
+#if NET45_OR_GREATER || NETSTANDARD2_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER
         /// <summary>
         /// Start the RoboCopy Process, then return the results.
         /// </summary>
@@ -446,7 +446,7 @@ namespace RoboSharp
                await process.WaitForExitAsync(); //Wait asynchronously for process to exit
                 results = resultsBuilder.BuildResults(process?.ExitCode ?? -1);
                Debugger.Instance.DebugMessage("RoboCopy process exited.");
-           }, cancellationToken, TaskCreationOptions.LongRunning, PriorityScheduler.BelowNormal);
+           }, cancellationToken, TaskCreationOptions.LongRunning, PriorityScheduler.BelowNormal).Unwrap();
 
             Task continueWithTask = backupTask.ContinueWith((continuation) => // this task always runs
             {

--- a/RoboSharp/RoboQueue.cs
+++ b/RoboSharp/RoboQueue.cs
@@ -614,7 +614,7 @@ namespace RoboSharp
                    while (MaxConcurrentJobs > 0 && JobsCurrentlyRunning >= MaxConcurrentJobs)
                        await ThreadEx.CancellableSleep(500, SleepCancelToken);
                }
-           }, cancellationToken, TaskCreationOptions.LongRunning, PriorityScheduler.BelowNormal);
+           }, cancellationToken, TaskCreationOptions.LongRunning, PriorityScheduler.BelowNormal).Unwrap();
 
             //After all commands have started, continue with waiting for all commands to complete.
             Task WhenAll = StartAll.ContinueWith((continuation) => Task.WaitAll(TaskList.ToArray(), cancellationToken), cancellationToken, TaskContinuationOptions.LongRunning, PriorityScheduler.BelowNormal);

--- a/RoboSharp/VersionManager.cs
+++ b/RoboSharp/VersionManager.cs
@@ -60,7 +60,7 @@ namespace RoboSharp
 
         private static string GetOsVersion()
         {
-#if NETSTANDARD2_1 || NETCOREAPP3_1
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
             using (var session = Microsoft.Management.Infrastructure.CimSession.Create("."))
 
             {
@@ -72,7 +72,7 @@ namespace RoboSharp
                 }
             }
 #endif
-#if NET40 || NET45
+#if NET40_OR_GREATER
             using (System.Management.ManagementObjectSearcher objMOS = new System.Management.ManagementObjectSearcher("SELECT * FROM  Win32_OperatingSystem"))
             {
                 foreach (System.Management.ManagementObject objManagement in objMOS.Get())


### PR DESCRIPTION
Also fixed PreCompile Directives not targeting targets_OR_GREATER

Resolve issue from this morning's post in #120 

I was running into the issue of starting too many commands with RoboQueue, which was hanging the TaskScheduler implementation since the tasks were running on threads that were being slept, meaning no more tasks could run on those threads. 

SO I had made the sleep and `Process.WaitForExit` asynchonrous.

Well, I found out that `Task.Factory.StartNew` doesn't natively handle Async Tasks, but `Task.Factory.Run` does.
`Task.Factory.Run` silently detects if you are producing `Task<Task>` and unwraps it automatically. `StartNew `is lower level, and you have to unwrap it yourself. I was unaware of this nuance when I made that change. 
After researching the issue, I found a MS article that explains the nuance of `Task.Factory.StartNew ( async() =>` creates a task that returns an async task, so the continuation task fires as soon as the inner async task has done the first 'await'. This caused RoboCommand.Stop() to be called, and reported results that weren't build yet, crashing everything.

I have added `.Unwrap()` to the end of the StartNew() task, which instead of returning Task<Task> will now simply return the inner task. Tested this morning and it works as it used to, but now doesn't block the entire thread since its waiting asynchronously.