### PR TITLE
Minor Fixes

### DIFF
--- a/RoboSharp.BackupApp/MainWindow.xaml.cs
+++ b/RoboSharp.BackupApp/MainWindow.xaml.cs
@@ -152,7 +152,7 @@ namespace RoboSharp.BackupApp
                 copy.CopyOptions.MonitorSourceChangesLimit = Convert.ToInt32(MonitorSourceChangesLimit.Text);
             if (!string.IsNullOrWhiteSpace(MonitorSourceTimeLimit.Text))
                 copy.CopyOptions.MonitorSourceTimeLimit = Convert.ToInt32(MonitorSourceTimeLimit.Text);
-            if (!string.IsNullOrWhiteSpace(RunHoursStartTime.Text)  && !string.IsNullOrWhiteSpace(RunHoursEndTime.Text))
+            if (!string.IsNullOrWhiteSpace(RunHoursStartTime.Text) && !string.IsNullOrWhiteSpace(RunHoursEndTime.Text))
             {
                 var s = $"{RunHoursStartTime.Text}-{RunHoursEndTime.Text}";
                 if (copy.CopyOptions.CheckRunHoursString(s))
@@ -169,8 +169,10 @@ namespace RoboSharp.BackupApp
             copy.SelectionOptions.OnlyCopyArchiveFilesAndResetArchiveFlag = OnlyCopyArchiveFilesAndResetArchiveFlag.IsChecked ?? false;
             copy.SelectionOptions.IncludeAttributes = IncludeAttributes.Text;
             copy.SelectionOptions.ExcludeAttributes = ExcludeAttributes.Text;
+#pragma warning disable CS0618 // These are marked as obsolete, but remain here for testing purposes. Properties were marked as obsolete due to backend change, but functionality should remain the same.
             copy.SelectionOptions.ExcludeFiles = ExcludeFiles.Text;
             copy.SelectionOptions.ExcludeDirectories = ExcludeDirectories.Text;
+#pragma warning restore CS0618 
             copy.SelectionOptions.ExcludeOlder = ExcludeOlder.IsChecked ?? false;
             copy.SelectionOptions.ExcludeJunctionPoints = ExcludeJunctionPoints.IsChecked ?? false;
 
@@ -234,8 +236,10 @@ namespace RoboSharp.BackupApp
             OnlyCopyArchiveFilesAndResetArchiveFlag.IsChecked = copy.SelectionOptions.OnlyCopyArchiveFilesAndResetArchiveFlag;
             IncludeAttributes.Text = copy.SelectionOptions.IncludeAttributes;
             ExcludeAttributes.Text = copy.SelectionOptions.ExcludeAttributes;
+#pragma warning disable CS0618 // These are marked as obsolete, but remain here for testing purposes. Properties were marked as obsolete due to backend change, but functionality should remain the same.
             ExcludeFiles.Text = copy.SelectionOptions.ExcludeFiles;
             ExcludeDirectories.Text = copy.SelectionOptions.ExcludeDirectories;
+#pragma warning restore CS0618
             ExcludeOlder.IsChecked = copy.SelectionOptions.ExcludeOlder;
             ExcludeJunctionPoints.IsChecked = copy.SelectionOptions.ExcludeJunctionPoints;
 

--- a/RoboSharp/JobFileBuilder.cs
+++ b/RoboSharp/JobFileBuilder.cs
@@ -471,8 +471,8 @@ namespace RoboSharp
                 else if (!xDParsed && !parsingXD && SelectionRegex_ExcludeDirs.IsMatch(ln))
                 {
                     // Paths are not expected to be on this output line
-                    parsingXF = true;
-                    parsingXD = false;
+                    parsingXF = false;
+                    parsingXD = true;
                 }
                 else if (LINE_IsSwitch.IsMatch(ln) || LINE_IsSwitch_NoComment.IsMatch(ln))
                 {


### PR DESCRIPTION
RoboCommand
- Fixed RoboCommand.Clone not including JobOptions
- RoboCommand now throws is starting a process while that command already has a process running.
- Insert WorkAround to allow saving of a RoboCopyJob while its running - this is done by cloning the command, then disposing of the clone.

SelectionOptions
- Improve ObsoleteTags to be more descriptive.
- Imrpove and test Regex.
- Hide Compiler warning in MainWindow