### PR TITLE
Overridable RoboCommand Properties and Methods

### DIFF
--- a/RoboSharp.BackupApp/MainWindow.xaml
+++ b/RoboSharp.BackupApp/MainWindow.xaml
@@ -208,6 +208,7 @@
                                             <RowDefinition />
                                             <RowDefinition />
                                             <RowDefinition />
+                                            <RowDefinition />
                                         </Grid.RowDefinitions>
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto" />
@@ -218,12 +219,14 @@
                                         <TextBlock Grid.Row="0" Grid.Column="0" Text="Verbose Output (/V)" />
                                         <TextBlock Grid.Row="1" Grid.Column="0" Text="No File Size (/NS)" />
                                         <TextBlock Grid.Row="2" Grid.Column="0" Text="No Progress (/NP)" />
+                                        <TextBlock Grid.Row="3" Grid.Column="0" Text="List Only (/L)" />
 
                                         <GridSplitter Width="5" Grid.Row="0" Grid.RowSpan="100" Grid.Column="1" ResizeBehavior="PreviousAndNext" ResizeDirection="Columns" />
 
                                         <CheckBox Grid.Row="0" Grid.Column="2" x:Name="VerboseOutput" Margin="10,0,0,0" IsChecked="True" />
                                         <CheckBox Grid.Row="1" Grid.Column="2" x:Name="NoFileSizes" Margin="10,0,0,0" />
                                         <CheckBox Grid.Row="2" Grid.Column="2" x:Name="NoProgress" Margin="10,0,0,0" />
+                                        <CheckBox Grid.Row="3" Grid.Column="2" x:Name="ChkListOnly" Margin="10,0,0,0" />
 
                                     </Grid>
                                 </Expander>

--- a/RoboSharp.BackupApp/MainWindow.xaml
+++ b/RoboSharp.BackupApp/MainWindow.xaml
@@ -147,6 +147,7 @@
                                             <RowDefinition />
                                             <RowDefinition />
                                             <RowDefinition />
+                                            <RowDefinition />
                                         </Grid.RowDefinitions>
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto" />
@@ -161,7 +162,8 @@
                                         <TextBlock Grid.Row="4" Grid.Column="0" Text="Exclude Files (/XF File File ...)" />
                                         <TextBlock Grid.Row="5" Grid.Column="0" Text="Exclude Directories (/XD Dir Dir ...)" />
                                         <TextBlock Grid.Row="6" Grid.Column="0" Text="Exclude Older (/XO)" />
-                                        <TextBlock Grid.Row="7" Grid.Column="0" Text="Exclude Junction Points (/XJ)" />
+                                        <TextBlock Grid.Row="7" Grid.Column="0" Text="Exclude NEWER (/XN)" />
+                                        <TextBlock Grid.Row="8" Grid.Column="0" Text="Exclude Junction Points (/XJ)" />
 
                                         <GridSplitter Width="5" Grid.Row="0" Grid.RowSpan="100" Grid.Column="1" ResizeBehavior="PreviousAndNext" ResizeDirection="Columns" />
 
@@ -172,7 +174,8 @@
                                         <TextBox Grid.Row="4" Grid.Column="2" x:Name="ExcludeFiles" Margin="10,0,0,0" ToolTip="Separate entries with space or comma&#x0a;If filename or path contains spaces then enclose in quotes&#x0a;e.g. &quot;my file.txt&quot;,file1.txt file2.txt"/>
                                         <TextBox Grid.Row="5" Grid.Column="2" x:Name="ExcludeDirectories" Margin="10,0,0,0" ToolTip="Separate entries with space or comma&#x0a;If filename or path contains spaces then enclose in quotes&#x0a;e.g. &quot;my file.txt&quot;,file1.txt file2.txt"/>
                                         <CheckBox Grid.Row="6" Grid.Column="2" x:Name="ExcludeOlder" Margin="10,0,0,0" />
-                                        <CheckBox Grid.Row="7" Grid.Column="2" x:Name="ExcludeJunctionPoints" Margin="10,0,0,0" />
+                                        <CheckBox Grid.Row="7" Grid.Column="2" x:Name="ExcludeNewer" Margin="10,0,0,0" />
+                                        <CheckBox Grid.Row="8" Grid.Column="2" x:Name="ExcludeJunctionPoints" Margin="10,0,0,0" />
 
                                     </Grid>
                                 </Expander>

--- a/RoboSharp.BackupApp/MainWindow.xaml.cs
+++ b/RoboSharp.BackupApp/MainWindow.xaml.cs
@@ -187,6 +187,7 @@ namespace RoboSharp.BackupApp
             copy.LoggingOptions.VerboseOutput = VerboseOutput.IsChecked ?? false;
             copy.LoggingOptions.NoFileSizes = NoFileSizes.IsChecked ?? false;
             copy.LoggingOptions.NoProgress = NoProgress.IsChecked ?? false;
+            copy.LoggingOptions.ListOnly = ChkListOnly.IsChecked ?? false;
             copy.StopIfDisposing = true;
             return copy;
         }
@@ -254,6 +255,7 @@ namespace RoboSharp.BackupApp
             VerboseOutput.IsChecked = copy.LoggingOptions.VerboseOutput;
             NoFileSizes.IsChecked = copy.LoggingOptions.NoFileSizes;
             NoProgress.IsChecked = copy.LoggingOptions.NoProgress;
+            ChkListOnly.IsChecked = copy.LoggingOptions.ListOnly;
         }
 
         void DebugMessage(object sender, Debugger.DebugMessageArgs e)

--- a/RoboSharp.BackupApp/MainWindow.xaml.cs
+++ b/RoboSharp.BackupApp/MainWindow.xaml.cs
@@ -175,6 +175,7 @@ namespace RoboSharp.BackupApp
 #pragma warning restore CS0618 
             copy.SelectionOptions.ExcludeOlder = ExcludeOlder.IsChecked ?? false;
             copy.SelectionOptions.ExcludeJunctionPoints = ExcludeJunctionPoints.IsChecked ?? false;
+            copy.SelectionOptions.ExcludeNewer = ExcludeNewer.IsChecked ?? false;
 
             // retry options
             if (!string.IsNullOrWhiteSpace(RetryCount.Text))
@@ -242,6 +243,8 @@ namespace RoboSharp.BackupApp
 #pragma warning restore CS0618
             ExcludeOlder.IsChecked = copy.SelectionOptions.ExcludeOlder;
             ExcludeJunctionPoints.IsChecked = copy.SelectionOptions.ExcludeJunctionPoints;
+            ExcludeNewer.IsChecked = copy.SelectionOptions.ExcludeNewer;
+
 
             // retry options
             RetryCount.Text = copy.RetryOptions.RetryCount.ToString();

--- a/RoboSharp/CopyOptions.cs
+++ b/RoboSharp/CopyOptions.cs
@@ -126,15 +126,15 @@ namespace RoboSharp
         /// <summary>
         /// The source file path where the RoboCommand is copying files from.
         /// </summary>
+        public virtual string Source { get { return _source; } set { _source = value.CleanDirectoryPath(); } }
         private string _source;
-        /// <inheritdoc cref="_source"/>
-        public string Source { get { return _source; } set { _source = value.CleanDirectoryPath(); } }
-        /// <summary>
-        /// The destination file path where the RoboCommand is copying files to.
+
+        /// <summary> 
+        /// The destination file path where the RoboCommand is copying files to. 
         /// </summary>
+        public virtual string Destination { get { return _destination; } set { _destination = value.CleanDirectoryPath(); } }
         private string _destination;
-        /// <inheritdoc cref="_destination"/>
-        public string Destination { get { return _destination; } set { _destination = value.CleanDirectoryPath(); } }
+
         /// <summary>
         /// Allows you to supply a set of files to copy or use wildcard characters (* or ?). <br/>
         /// JobOptions file saves these into the /IF (Include Files) section
@@ -154,43 +154,43 @@ namespace RoboSharp
         /// Copies subdirectories. Note that this option excludes empty directories.
         /// [/S]
         /// </summary>
-        public bool CopySubdirectories { get; set; }
+        public virtual bool CopySubdirectories { get; set; }
         /// <summary>
         /// Copies subdirectories. Note that this option includes empty directories.
         /// [/E]
         /// </summary>
-        public bool CopySubdirectoriesIncludingEmpty { get; set; }
+        public virtual bool CopySubdirectoriesIncludingEmpty { get; set; }
         /// <summary>
         /// Copies only the top N levels of the source directory tree. The default is
         /// zero which does not limit the depth.
         /// [/LEV:N]
         /// </summary>
-        public int Depth { get; set; }
+        public virtual int Depth { get; set; }
         /// <summary>
         /// Copies files in Restart mode.
         /// [/Z]
         /// </summary>
-        public bool EnableRestartMode { get; set; }
+        public virtual bool EnableRestartMode { get; set; }
         /// <summary>
         /// Copies files in Backup mode.
         /// [/B]
         /// </summary>
-        public bool EnableBackupMode { get; set; }
+        public virtual bool EnableBackupMode { get; set; }
         /// <summary>
         /// Uses Restart mode. If access is denied, this option uses Backup mode.
         /// [/ZB]
         /// </summary>
-        public bool EnableRestartModeWithBackupFallback { get; set; }
+        public virtual bool EnableRestartModeWithBackupFallback { get; set; }
         /// <summary>
         /// Copy using unbuffered I/O (recommended for large files).
         /// [/J]
         /// </summary>
-        public bool UseUnbufferedIo { get; set; }
+        public virtual bool UseUnbufferedIo { get; set; }
         /// <summary>
         /// Copies all encrypted files in EFS RAW mode.
         /// [/EFSRAW]
         /// </summary>
-        public bool EnableEfsRawMode { get; set; }
+        public virtual bool EnableEfsRawMode { get; set; }
         /// <summary>
         /// This property should be set to a string consisting of all the flags to include (eg. DAT; DATSOU)
         /// Specifies the file properties to be copied. The following are the valid values for this option:
@@ -215,47 +215,47 @@ namespace RoboSharp
         /// Copies files with security (equivalent to /copy:DAT).
         /// [/SEC]
         /// </summary>
-        public bool CopyFilesWithSecurity { get; set; }
+        public virtual bool CopyFilesWithSecurity { get; set; }
         /// <summary>
         /// Copies all file information (equivalent to /copy:DATSOU).
         /// [/COPYALL]
         /// </summary>
-        public bool CopyAll { get; set; }
+        public virtual bool CopyAll { get; set; }
         /// <summary>
         /// Copies no file information (useful with Purge option).
         /// [/NOCOPY]
         /// </summary>
-        public bool RemoveFileInformation { get; set; }
+        public virtual bool RemoveFileInformation { get; set; }
         /// <summary>
         /// Fixes file security on all files, even skipped ones.
         /// [/SECFIX]
         /// </summary>
-        public bool FixFileSecurityOnAllFiles { get; set; }
+        public virtual bool FixFileSecurityOnAllFiles { get; set; }
         /// <summary>
         /// Fixes file times on all files, even skipped ones.
         /// [/TIMFIX]
         /// </summary>
-        public bool FixFileTimesOnAllFiles { get; set; }
+        public virtual bool FixFileTimesOnAllFiles { get; set; }
         /// <summary>
         /// Deletes destination files and directories that no longer exist in the source.
         /// [/PURGE]
         /// </summary>
-        public bool Purge { get; set; }
+        public virtual bool Purge { get; set; }
         /// <summary>
         /// Mirrors a directory tree (equivalent to CopySubdirectoriesIncludingEmpty plus Purge).
         /// [/MIR]
         /// </summary>
-        public bool Mirror { get; set; }
+        public virtual bool Mirror { get; set; }
         /// <summary>
         /// Moves files, and deletes them from the source after they are copied.
         /// [/MOV]
         /// </summary>
-        public bool MoveFiles { get; set; }
+        public virtual bool MoveFiles { get; set; }
         /// <summary>
         /// Moves files and directories, and deletes them from the source after they are copied.
         /// [/MOVE]
         /// </summary>
-        public bool MoveFilesAndDirectories { get; set; }
+        public virtual bool MoveFilesAndDirectories { get; set; }
         /// <summary>
         /// This property should be set to a string consisting of all the attributes to add (eg. AH; RASHCNET).
         /// Adds the specified attributes to copied files.
@@ -272,29 +272,29 @@ namespace RoboSharp
         /// Creates a directory tree and zero-length files only.
         /// [/CREATE]
         /// </summary>
-        public bool CreateDirectoryAndFileTree { get; set; }
+        public virtual bool CreateDirectoryAndFileTree { get; set; }
         /// <summary>
         /// Creates destination files by using 8.3 character-length FAT file names only.
         /// [/FAT]
         /// </summary>
-        public bool FatFiles { get; set; }
+        public virtual bool FatFiles { get; set; }
         /// <summary>
         /// Turns off support for very long paths (longer than 256 characters).
         /// [/256]
         /// </summary>
-        public bool TurnLongPathSupportOff { get; set; }
+        public virtual bool TurnLongPathSupportOff { get; set; }
         /// <summary>
         /// The default value of zero indicates that you do not wish to monitor for changes.
         /// Monitors the source, and runs again when more than N changes are detected.
         /// [/MON:N]
         /// </summary>
-        public int MonitorSourceChangesLimit { get; set; }
+        public virtual int MonitorSourceChangesLimit { get; set; }
         /// <summary>
         /// The default value of zero indicates that you do not wish to monitor for changes.
         /// Monitors source, and runs again in M minutes if changes are detected.
         /// [/MOT:M]
         /// </summary>
-        public int MonitorSourceTimeLimit { get; set; }
+        public virtual int MonitorSourceTimeLimit { get; set; }
         /// <summary>
         /// Specifies run times when new copies may be started. ( Copy Operation is scheduled to only operate within specified timeframe )
         /// [/rh:hhmm-hhmm] <br/>
@@ -324,27 +324,27 @@ namespace RoboSharp
         /// Checks the scheduled /RH (run hours) per file instead of per pass.
         /// [/PF]
         /// </summary>
-        public bool CheckPerFile { get; set; }
+        public virtual bool CheckPerFile { get; set; }
 
-	    /// <summary>
-	    /// The default value of zero indicates that this feature is turned off.
-	    /// Specifies the inter-packet gap to free bandwidth on slow lines.
-	    /// [/IPG:N]
-	    /// </summary>
-	    public int InterPacketGap { get; set; }
+        /// <summary>
+        /// The default value of zero indicates that this feature is turned off.
+        /// Specifies the inter-packet gap to free bandwidth on slow lines.
+        /// [/IPG:N]
+        /// </summary>
+        public virtual int InterPacketGap { get; set; }
         /// <summary>
         /// Copies the symbolic link instead of the target.
         /// [/SL]
         /// </summary>
-        public bool CopySymbolicLink { get; set; }
+        public virtual bool CopySymbolicLink { get; set; }
 
-	    /// <summary>
-	    /// The default value of zero indicates that this feature is turned off.
-	    /// Creates multi-threaded copies with N threads. Must be an integer between 1 and 128.
-	    /// The MultiThreadedCopiesCount parameter cannot be used with the /IPG and EnableEfsRawMode parameters.
-	    /// [/MT:N]
-	    /// </summary>
-	    public int MultiThreadedCopiesCount { get; set; }
+        /// <summary>
+        /// The default value of zero indicates that this feature is turned off.
+        /// Creates multi-threaded copies with N threads. Must be an integer between 1 and 128.
+        /// The MultiThreadedCopiesCount parameter cannot be used with the /IPG and EnableEfsRawMode parameters.
+        /// [/MT:N]
+        /// </summary>
+        public virtual int MultiThreadedCopiesCount { get; set; }
         /// <summary>
         /// What to copy for directories (default is DA).
         /// (copyflags: D=Data, A=Attributes, T=Timestamps).
@@ -359,12 +359,12 @@ namespace RoboSharp
         /// Do not copy any directory info.
         /// [/NODCOPY]
         /// </summary>
-        public bool DoNotCopyDirectoryInfo { get; set; }
+        public virtual bool DoNotCopyDirectoryInfo { get; set; }
         /// <summary>
         /// Copy files without using the Windows Copy Offload mechanism.
         /// [/NOOFFLOAD]
         /// </summary>
-        public bool DoNotUseWindowsCopyOffload { get; set; }
+        public virtual bool DoNotUseWindowsCopyOffload { get; set; }
 
         #endregion Public Properties
 

--- a/RoboSharp/CopyOptions.cs
+++ b/RoboSharp/CopyOptions.cs
@@ -28,7 +28,7 @@ namespace RoboSharp
         /// <param name="copyOptions">CopyOptions object to clone</param>
         /// <param name="NewSource">Specify a new source if desired. If left as null, will use Source from <paramref name="copyOptions"/></param>
         /// <param name="NewDestination">Specify a new source if desired. If left as null, will use Destination from <paramref name="copyOptions"/></param>
-        public CopyOptions(CopyOptions copyOptions, string NewSource = null, string NewDestination = null) 
+        public CopyOptions(CopyOptions copyOptions, string NewSource = null, string NewDestination = null)
         {
             Source = NewSource ?? copyOptions.Source;
             Destination = NewDestination ?? copyOptions.Destination;
@@ -41,32 +41,32 @@ namespace RoboSharp
             CopySubdirectories = copyOptions.CopySubdirectories;
             CopySubdirectoriesIncludingEmpty = copyOptions.CopySubdirectoriesIncludingEmpty;
             CopySymbolicLink = copyOptions.CopySymbolicLink;
-            CreateDirectoryAndFileTree= copyOptions.CreateDirectoryAndFileTree;
-            Depth= copyOptions.Depth;
-            DirectoryCopyFlags= copyOptions.DirectoryCopyFlags;
-            DoNotCopyDirectoryInfo= copyOptions.DoNotCopyDirectoryInfo;
-            DoNotUseWindowsCopyOffload= copyOptions.DoNotUseWindowsCopyOffload;
-            EnableBackupMode= copyOptions.EnableBackupMode;
+            CreateDirectoryAndFileTree = copyOptions.CreateDirectoryAndFileTree;
+            Depth = copyOptions.Depth;
+            DirectoryCopyFlags = copyOptions.DirectoryCopyFlags;
+            DoNotCopyDirectoryInfo = copyOptions.DoNotCopyDirectoryInfo;
+            DoNotUseWindowsCopyOffload = copyOptions.DoNotUseWindowsCopyOffload;
+            EnableBackupMode = copyOptions.EnableBackupMode;
             EnableEfsRawMode = copyOptions.EnableEfsRawMode;
             EnableRestartMode = copyOptions.EnableRestartMode;
             EnableRestartModeWithBackupFallback = copyOptions.EnableRestartModeWithBackupFallback;
             FatFiles = copyOptions.FatFiles;
-            FileFilter= copyOptions.FileFilter;
-            FixFileSecurityOnAllFiles= copyOptions.FixFileSecurityOnAllFiles;
-            FixFileTimesOnAllFiles= copyOptions.FixFileTimesOnAllFiles;
-            InterPacketGap= copyOptions.InterPacketGap;
-            Mirror= copyOptions.Mirror;
-            MonitorSourceChangesLimit= copyOptions.MonitorSourceChangesLimit;
-            MonitorSourceTimeLimit= copyOptions.MonitorSourceTimeLimit;
-            MoveFiles= copyOptions.MoveFiles;
-            MoveFilesAndDirectories= copyOptions.MoveFilesAndDirectories;
-            MultiThreadedCopiesCount= copyOptions.MultiThreadedCopiesCount;
-            Purge= copyOptions.Purge;
-            RemoveAttributes= copyOptions.RemoveAttributes;
-            RemoveFileInformation= copyOptions.RemoveFileInformation;
-            RunHours= copyOptions.RunHours;
-            TurnLongPathSupportOff= copyOptions.TurnLongPathSupportOff;
-            UseUnbufferedIo= copyOptions.UseUnbufferedIo;
+            FileFilter = copyOptions.FileFilter;
+            FixFileSecurityOnAllFiles = copyOptions.FixFileSecurityOnAllFiles;
+            FixFileTimesOnAllFiles = copyOptions.FixFileTimesOnAllFiles;
+            InterPacketGap = copyOptions.InterPacketGap;
+            Mirror = copyOptions.Mirror;
+            MonitorSourceChangesLimit = copyOptions.MonitorSourceChangesLimit;
+            MonitorSourceTimeLimit = copyOptions.MonitorSourceTimeLimit;
+            MoveFiles = copyOptions.MoveFiles;
+            MoveFilesAndDirectories = copyOptions.MoveFilesAndDirectories;
+            MultiThreadedCopiesCount = copyOptions.MultiThreadedCopiesCount;
+            Purge = copyOptions.Purge;
+            RemoveAttributes = copyOptions.RemoveAttributes;
+            RemoveFileInformation = copyOptions.RemoveFileInformation;
+            RunHours = copyOptions.RunHours;
+            TurnLongPathSupportOff = copyOptions.TurnLongPathSupportOff;
+            UseUnbufferedIo = copyOptions.UseUnbufferedIo;
         }
 
         /// <inheritdoc cref="CopyOptions.CopyOptions(CopyOptions, string, string)"/>
@@ -310,7 +310,7 @@ namespace RoboSharp
         public string RunHours
         {
             get => runHours;
-            set 
+            set
             {
                 if (String.IsNullOrWhiteSpace(value))
                     runHours = value?.Trim() ?? string.Empty;

--- a/RoboSharp/DefaultConfigurations/RoboSharpConfig_DE.cs
+++ b/RoboSharp/DefaultConfigurations/RoboSharpConfig_DE.cs
@@ -22,12 +22,14 @@ namespace RoboSharp.DefaultConfigurations
             //LogParsing_ExtraFile = "*EXTRA File";
             //LogParsing_MismatchFile = "*Mismatch";
             //LogParsing_FailedFile = "*Failed";
+            //LogParsing_FileExclusion = "named";
 
             // < Directory Tokens >
 
             //LogParsing_NewDir = "New Dir";
             //LogParsing_ExtraDir = "*EXTRA Dir";
             //LogParsing_ExistingDir = "Existing Dir";
+            //LogParsing_DirectoryExclusion = "named";
 
         }
     }

--- a/RoboSharp/DefaultConfigurations/RoboSharpConfig_EN.cs
+++ b/RoboSharp/DefaultConfigurations/RoboSharpConfig_EN.cs
@@ -25,13 +25,14 @@ namespace RoboSharp.DefaultConfigurations
             LogParsing_ExtraFile = "*EXTRA File";
             LogParsing_MismatchFile = "*Mismatch";
             LogParsing_FailedFile = "*Failed";
+            LogParsing_FileExclusion = "named";
 
             // < Directory Tokens >
 
             LogParsing_NewDir = "New Dir";
             LogParsing_ExtraDir = "*EXTRA Dir";
             LogParsing_ExistingDir = "Existing Dir";
-
+            LogParsing_DirectoryExclusion = "named";
         }
     }
 }

--- a/RoboSharp/ExtensionMethods.cs
+++ b/RoboSharp/ExtensionMethods.cs
@@ -242,37 +242,3 @@ namespace System.Threading
         }
     }
 }
-
-namespace System.Diagnostics
-{
-    /// <summary>
-    /// Contains methods for Process.WaitForExitAsync
-    /// </summary>
-    internal static class ProcessExtensions
-    {
-        /// <summary>
-        /// Create a task that asynchronously waits for a process to exit. <see cref="Process.HasExited"/> will be evaluated every 100ms.
-        /// </summary>
-        /// <inheritdoc cref="WaitForExitAsync(Process, int, CancellationToken)"/>
-        [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
-        internal static async Task WaitForExitAsync(this Process process, CancellationToken token)
-        {
-            while (!token.IsCancellationRequested && !process.HasExited)
-                await Task.Delay(100, token).ContinueWith(t => t.Exception == default);
-        }
-
-        /// <summary>
-        /// Create a task that asynchronously waits for a process to exit.
-        /// </summary>
-        /// <param name="process">Process to wait for</param>
-        /// <param name="interval">interval (Milliseconds) to evaluate <see cref="Process.HasExited"/></param>
-        /// <param name="token"></param>
-        /// <returns></returns>
-        [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
-        internal static async Task WaitForExitAsync(this Process process, int interval, CancellationToken token)
-        {
-            while (!token.IsCancellationRequested && !process.HasExited)
-                await Task.Delay(interval, token).ContinueWith( t => t.Exception == default);
-        }
-    }
-}

--- a/RoboSharp/Interfaces/IRoboCommand.cs
+++ b/RoboSharp/Interfaces/IRoboCommand.cs
@@ -88,13 +88,27 @@ namespace RoboSharp.Interfaces
         
         /// <inheritdoc cref="RoboCommand.Start(string, string, string)"/>
         Task Start(string domain = "", string username = "", string password = "");
-        
+
+        /// <inheritdoc cref="RoboCommand.Start_ListOnly(string, string, string)"/>
+        Task Start_ListOnly(string domain = "", string username = "", string password = "");
+
         /// <inheritdoc cref="RoboCommand.Stop()"/>
         void Stop();
         
         /// <inheritdoc cref="RoboCommand.Dispose()"/>
         void Dispose();
-        
+
+#if NET45_OR_GREATER || NETSTANDARD2_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER
+
+        /// <inheritdoc cref="RoboCommand.StartAsync_ListOnly(string, string, string)"/>
+        Task<Results.RoboCopyResults> StartAsync_ListOnly(string domain = "", string username = "", string password = "");
+
+        /// <inheritdoc cref="RoboCommand.StartAsync(string, string, string)"/>
+        Task<Results.RoboCopyResults> StartAsync(string domain = "", string username = "", string password = "");
+
+#endif
+
+
         #endregion Methods
     }
 }

--- a/RoboSharp/Interfaces/IRoboCopyResultsList.cs
+++ b/RoboSharp/Interfaces/IRoboCopyResultsList.cs
@@ -31,6 +31,9 @@ namespace RoboSharp.Interfaces
         /// <summary> Sum of all RoboCopyExitStatus objects </summary>
         IRoboCopyCombinedExitStatus Status { get; }
 
+        /// <summary> Collection of all RoboCopy Results contained within the list </summary>    
+        IReadOnlyList<RoboCopyResults> Collection { get; }
+
         /// <inheritdoc cref="List{T}.Count"/>
         int Count { get; }
 

--- a/RoboSharp/Interfaces/IRoboCopyResultsList.cs
+++ b/RoboSharp/Interfaces/IRoboCopyResultsList.cs
@@ -8,6 +8,9 @@ namespace RoboSharp.Interfaces
 {
     /// <summary>
     /// Interface to provide Read-Only access to a <see cref="RoboCopyResultsList"/>
+    /// <para/>Implements: <br/>
+    /// <see cref="IEnumerable{T}"/> where T = <see cref="RoboCopyResults"/> <br/>
+    /// <see cref="ICloneable"/>
     /// </summary>
     /// <remarks>
     /// <see href="https://github.com/tjscience/RoboSharp/wiki/IRoboCopyResultsList"/>
@@ -16,25 +19,25 @@ namespace RoboSharp.Interfaces
     {
         #region < Properties >
 
-        /// <summary> Sum of all DirectoryStatistics objects </summary>
+        /// <inheritdoc cref="RoboCopyResultsList.DirectoriesStatistic"/>
         IStatistic DirectoriesStatistic { get; }
 
-        /// <summary> Sum of all ByteStatistics objects </summary>
+        /// <inheritdoc cref="RoboCopyResultsList.BytesStatistic"/>
         IStatistic BytesStatistic { get; }
 
-        /// <summary> Sum of all FileStatistics objects </summary>
+        /// <inheritdoc cref="RoboCopyResultsList.FilesStatistic"/>
         IStatistic FilesStatistic { get; }
 
-        /// <summary> Average of all SpeedStatistics objects </summary>
+        /// <inheritdoc cref="RoboCopyResultsList.SpeedStatistic"/>
         ISpeedStatistic SpeedStatistic { get; }
 
-        /// <summary> Sum of all RoboCopyExitStatus objects </summary>
+        /// <inheritdoc cref="RoboCopyResultsList.Status"/>
         IRoboCopyCombinedExitStatus Status { get; }
 
-        /// <summary> Collection of all RoboCopy Results contained within the list </summary>    
+        /// <inheritdoc cref="RoboCopyResultsList.Collection"/>
         IReadOnlyList<RoboCopyResults> Collection { get; }
 
-        /// <inheritdoc cref="List{T}.Count"/>
+        /// <inheritdoc cref="RoboCopyResultsList.Count"/>
         int Count { get; }
 
         #endregion

--- a/RoboSharp/Interfaces/IRoboQueue.cs
+++ b/RoboSharp/Interfaces/IRoboQueue.cs
@@ -1,0 +1,139 @@
+﻿using RoboSharp.Interfaces;
+using RoboSharp.Results;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Threading.Tasks;
+
+namespace RoboSharp.Interfaces
+{
+    /// <summary>
+    /// Interface for RoboQueue
+    /// </summary>
+    public interface IRoboQueue : IDisposable, INotifyPropertyChanged, IEnumerable<IRoboCommand>
+    {
+        #region < Properties >
+
+        /// <inheritdoc cref="RoboQueue.AnyCancelled"/>
+        bool AnyCancelled { get; }
+
+        /// <inheritdoc cref="RoboQueue.AnyPaused"/>
+        bool AnyPaused { get; }
+
+        /// <inheritdoc cref="RoboQueue.AnyRunning"/>
+        bool AnyRunning { get; }
+
+        /// <inheritdoc cref="RoboQueue.Commands"/>
+        ReadOnlyCollection<IRoboCommand> Commands { get; }
+
+        /// <inheritdoc cref="RoboQueue.CopyOperationCompleted"/>
+        bool CopyOperationCompleted { get; }
+
+        /// <inheritdoc cref="RoboQueue.IsCopyOperationRunning"/>
+        bool IsCopyOperationRunning { get; }
+
+        /// <inheritdoc cref="RoboQueue.IsListOnlyRunning"/>
+        bool IsListOnlyRunning { get; }
+
+        /// <inheritdoc cref="RoboQueue.IsPaused"/>
+        bool IsPaused { get; }
+
+        /// <inheritdoc cref="RoboQueue.IsRunning"/>
+        bool IsRunning { get; }
+
+        /// <inheritdoc cref="RoboQueue.JobsComplete"/>
+        int JobsComplete { get; }
+
+        /// <inheritdoc cref="RoboQueue.JobsCompletedSuccessfully"/>
+        int JobsCompletedSuccessfully { get; }
+
+        /// <inheritdoc cref="RoboQueue.JobsCurrentlyRunning"/>
+        int JobsCurrentlyRunning { get; }
+
+        /// <inheritdoc cref="RoboQueue.JobsStarted"/>
+        int JobsStarted { get; }
+
+        /// <inheritdoc cref="RoboQueue.ListCount"/>
+        int ListCount { get; }
+
+        /// <inheritdoc cref="RoboQueue.ListOnlyCompleted"/>
+        bool ListOnlyCompleted { get; }
+
+        /// <inheritdoc cref="RoboQueue.ListResults"/>
+        IRoboCopyResultsList ListResults { get; }
+
+        /// <inheritdoc cref="RoboQueue.MaxConcurrentJobs"/>
+        int MaxConcurrentJobs { get; set; }
+
+        /// <inheritdoc cref="RoboQueue.Name"/>
+        string Name { get; }
+
+        /// <inheritdoc cref="RoboQueue.ProgressEstimator"/>
+        IProgressEstimator ProgressEstimator { get; }
+
+        /// <inheritdoc cref="RoboQueue.RunResults"/>
+        IRoboCopyResultsList RunResults { get; }
+
+        /// <inheritdoc cref="RoboQueue.WasCancelled"/>
+        bool WasCancelled { get; }
+
+        #endregion
+
+        #region < Events >
+
+
+        /// <inheritdoc cref="RoboQueue.OnCommandCompleted"/>
+        event RoboCommand.CommandCompletedHandler OnCommandCompleted;
+
+        /// <inheritdoc cref="RoboQueue.OnCommandError"/>
+        event RoboCommand.CommandErrorHandler OnCommandError;
+
+        /// <inheritdoc cref="RoboQueue.OnCommandStarted"/>
+        event RoboQueue.CommandStartedHandler OnCommandStarted;
+
+        /// <inheritdoc cref="RoboQueue.OnCopyProgressChanged"/>
+        event RoboCommand.CopyProgressHandler OnCopyProgressChanged;
+
+        /// <inheritdoc cref="RoboQueue.OnError"/>
+        event RoboCommand.ErrorHandler OnError;
+
+        /// <inheritdoc cref="RoboQueue.OnFileProcessed"/>
+        event RoboCommand.FileProcessedHandler OnFileProcessed;
+
+        /// <inheritdoc cref="RoboQueue.OnProgressEstimatorCreated"/>
+        event RoboQueue.ProgressUpdaterCreatedHandler OnProgressEstimatorCreated;
+
+        /// <inheritdoc cref="RoboQueue.RunCompleted"/>
+        event RoboQueue.RunCompletedHandler RunCompleted;
+
+        /// <inheritdoc cref="RoboQueue.RunResultsUpdated"/>
+        event RoboCopyResultsList.ResultsListUpdated RunResultsUpdated;
+
+        /// <inheritdoc cref="RoboQueue.TaskFaulted"/>
+        event UnhandledExceptionEventHandler TaskFaulted;
+
+        #endregion
+
+        #region < Methods >
+
+
+        /// <inheritdoc cref="RoboQueue.PauseAll"/>
+        void PauseAll();
+
+        /// <inheritdoc cref="RoboQueue.ResumeAll"/>
+        void ResumeAll();
+
+        /// <inheritdoc cref="RoboQueue.StartAll"/>
+        Task<IRoboCopyResultsList> StartAll(string domain = "", string username = "", string password = "");
+
+        /// <inheritdoc cref="RoboQueue.StartAll_ListOnly"/>
+        Task<IRoboCopyResultsList> StartAll_ListOnly(string domain = "", string username = "", string password = "");
+
+        /// <inheritdoc cref="RoboQueue.StopAll"/>
+        void StopAll();
+
+        #endregion
+    }
+}

--- a/RoboSharp/JobFile.cs
+++ b/RoboSharp/JobFile.cs
@@ -12,6 +12,9 @@ namespace RoboSharp
 {
     /// <summary>
     /// Represents a single RoboCopy Job File
+    /// <para/>Implements: <br/>
+    /// <see cref="IRoboCommand"/> <br/>
+    /// <see cref="ICloneable"/> <br/>
     /// </summary>
     /// <remarks>
     /// <see href="https://github.com/tjscience/RoboSharp/wiki/JobFile"/>

--- a/RoboSharp/JobFile.cs
+++ b/RoboSharp/JobFile.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using RoboSharp.Interfaces;
 using System.Threading.Tasks;
+using RoboSharp.Results;
 
 namespace RoboSharp
 {
@@ -318,6 +319,21 @@ namespace RoboSharp
         void IRoboCommand.Dispose()
         {
             roboCommand.Stop();
+        }
+
+        Task IRoboCommand.Start_ListOnly(string domain, string username, string password)
+        {
+            return roboCommand.Start_ListOnly();
+        }
+
+        Task<RoboCopyResults> IRoboCommand.StartAsync_ListOnly(string domain, string username, string password)
+        {
+            return roboCommand.StartAsync_ListOnly();
+        }
+
+        Task<RoboCopyResults> IRoboCommand.StartAsync(string domain, string username, string password)
+        {
+            return roboCommand.StartAsync_ListOnly();
         }
         #endregion
 

--- a/RoboSharp/JobFile.cs
+++ b/RoboSharp/JobFile.cs
@@ -288,7 +288,7 @@ namespace RoboSharp
         LoggingOptions IRoboCommand.LoggingOptions { get => roboCommand.LoggingOptions; set => roboCommand.LoggingOptions = value; }
         CopyOptions IRoboCommand.CopyOptions { get => ((IRoboCommand)roboCommand).CopyOptions; set => ((IRoboCommand)roboCommand).CopyOptions = value; }
         JobOptions IRoboCommand.JobOptions { get => ((IRoboCommand)roboCommand).JobOptions; }
-        RoboSharpConfiguration IRoboCommand.Configuration => roboCommand.Configuration; 
+        RoboSharpConfiguration IRoboCommand.Configuration => roboCommand.Configuration;
         string IRoboCommand.CommandOptions => roboCommand.CommandOptions;
 
         #endregion

--- a/RoboSharp/JobFile.cs
+++ b/RoboSharp/JobFile.cs
@@ -127,14 +127,14 @@ namespace RoboSharp
         /// <summary>
         /// Options are stored in a RoboCommand object for simplicity.
         /// </summary>
-        private RoboCommand roboCommand;
+        protected RoboCommand roboCommand;
 
         #endregion
 
         #region < Properties >
 
         /// <summary>FilePath of the Job File </summary>
-        public string FilePath { get; set; }
+        public virtual string FilePath { get; set; }
 
         /// <inheritdoc cref="RoboCommand.Name"/>
         public string Job_Name

--- a/RoboSharp/JobOptions.cs
+++ b/RoboSharp/JobOptions.cs
@@ -99,7 +99,7 @@ namespace RoboSharp
         /// This causes RoboCopy to generate an RCJ file where the command options are stored to so it can be used later.<br/>
         /// <see cref="NoSourceDirectory"/> and <see cref="NoDestinationDirectory"/> options are only evaluated if this is set. <br/>
         /// </remarks>
-        public string FilePath { get; set; } = "";
+        public virtual string FilePath { get; set; } = "";
 
         /// <summary>
         /// RoboCopy will validate the command, then exit before performing any Move/Copy/List operations. <br/>
@@ -108,7 +108,7 @@ namespace RoboSharp
         /// <remarks>
         /// This option is typically used when generating JobFiles. RoboCopy will exit after saving the Job FIle to the specified <see cref="FilePath"/>
         /// </remarks>
-        public bool PreventCopyOperation { get; set; }
+        public virtual bool PreventCopyOperation { get; set; }
 
         /// <summary>
         /// <see cref="CopyOptions.Source"/> path will not be saved to the JobFile. <br/>
@@ -117,7 +117,7 @@ namespace RoboSharp
         /// <remarks>
         /// Default value is False, meaning if <see cref="CopyOptions.Source"/> is set, it will be saved to the JobFile RoboCopy generates.
         /// </remarks>
-        public bool NoSourceDirectory { get; set; }
+        public virtual bool NoSourceDirectory { get; set; }
 
         /// <summary>
         /// <see cref="CopyOptions.Destination"/> path will not be saved to the JobFile. <br/>
@@ -126,7 +126,7 @@ namespace RoboSharp
         /// <remarks>
         /// Default value is False, meaning if <see cref="CopyOptions.Destination"/> is set, it will be saved to the JobFile RoboCopy generates.
         /// </remarks>
-        public bool NoDestinationDirectory { get; set; }
+        public virtual bool NoDestinationDirectory { get; set; }
         #endregion
 
         #region < Methods >

--- a/RoboSharp/LoggingOptions.cs
+++ b/RoboSharp/LoggingOptions.cs
@@ -79,104 +79,104 @@ namespace RoboSharp
         /// Do not copy, timestamp or delete any files.
         /// [/L]
         /// </summary>
-        public bool ListOnly { get; set; }
+        public virtual bool ListOnly { get; set; }
         /// <summary>
         /// Report all extra files, not just those selected.
         /// [X]
         /// </summary>
-        public bool ReportExtraFiles { get; set; }
+        public virtual bool ReportExtraFiles { get; set; }
         /// <summary>
         /// Produce verbose output, showing skipped files.
         /// [V]
         /// </summary>
-        public bool VerboseOutput { get; set; }
+        public virtual bool VerboseOutput { get; set; }
         /// <summary>
         /// Include source file time stamps in the output.
         /// [/TS]
         /// </summary>
-        public bool IncludeSourceTimeStamps { get; set; }
+        public virtual bool IncludeSourceTimeStamps { get; set; }
         /// <summary>
         /// Include full path names of files in the output.
         /// [/FP]
         /// </summary>
-        public bool IncludeFullPathNames { get; set; }
+        public virtual bool IncludeFullPathNames { get; set; }
         /// <summary>
         /// Print sizes as bytes in the output.
         /// [/BYTES]
         /// </summary>
-        public bool PrintSizesAsBytes { get; set; }
+        public virtual bool PrintSizesAsBytes { get; set; }
         /// <summary>
         /// Do not log file sizes.
         /// [/NS]
         /// </summary>
-        public bool NoFileSizes { get; set; }
+        public virtual bool NoFileSizes { get; set; }
         /// <summary>
         /// Do not log file classes.
         /// [/NC]
         /// </summary>
-        public bool NoFileClasses { get; set; }
+        public virtual bool NoFileClasses { get; set; }
         /// <summary>
         /// Do not log file names.
         /// [/NFL]
         /// WARNING: If this is set to TRUE then GUI cannot handle showing progress correctly as it can't get information it requires from the log
         /// </summary>
-        public bool NoFileList { get; set; }
+        public virtual bool NoFileList { get; set; }
         /// <summary>
         /// Do not log directory names.
         /// [/NDL]
         /// </summary>
-        public bool NoDirectoryList { get; set; }
+        public virtual bool NoDirectoryList { get; set; }
         /// <summary>
         /// Do not log percentage copied.
         /// [/NP]
         /// </summary>
-        public bool NoProgress { get; set; }
+        public virtual bool NoProgress { get; set; }
         /// <summary>
         /// Show estimated time of arrival of copied files.
         /// [/ETA]
         /// </summary>
-        public bool ShowEstimatedTimeOfArrival { get; set; }
+        public virtual bool ShowEstimatedTimeOfArrival { get; set; }
         /// <summary>
         /// Output status to LOG file (overwrite existing log).
         /// [/LOG:file]
         /// </summary>
-        public string LogPath { get; set; }
+        public virtual string LogPath { get; set; }
         /// <summary>
         /// Output status to LOG file (append to existing log).
         /// [/LOG+:file]
         /// </summary>
-        public string AppendLogPath { get; set; }
+        public virtual string AppendLogPath { get; set; }
         /// <summary>
         /// Output status to LOG file as UNICODE (overwrite existing log).
         /// [/UNILOG:file]
         /// </summary>
-        public string UnicodeLogPath { get; set; }
+        public virtual string UnicodeLogPath { get; set; }
         /// <summary>
         /// Output status to LOG file as UNICODE (append to existing log).
         /// [/UNILOG+:file]
         /// </summary>
-        public string AppendUnicodeLogPath { get; set; }
+        public virtual string AppendUnicodeLogPath { get; set; }
         /// <summary>
         /// Output to RoboSharp and Log.
         /// [/TEE]
         /// </summary>
-        public bool OutputToRoboSharpAndLog { get; set; }
+        public virtual bool OutputToRoboSharpAndLog { get; set; }
         /// <summary>
         /// Do not output a Job Header.
         /// [/NJH]
         /// </summary>
-        public bool NoJobHeader { get; set; }
+        public virtual bool NoJobHeader { get; set; }
         /// <summary>
         /// Do not output a Job Summary.
         /// [/NJS]
         /// WARNING: If this is set to TRUE then statistics will not work correctly as this information is gathered from the job summary part of the log 
         /// </summary>
-        public bool NoJobSummary { get; set; }
+        public virtual bool NoJobSummary { get; set; }
         /// <summary>
         /// Output as UNICODE.
         /// [/UNICODE]
         /// </summary>
-        public bool OutputAsUnicode { get; set; }
+        public virtual bool OutputAsUnicode { get; set; }
 
         /// <summary> Encase the LogPath in quotes if needed </summary>
         internal string WrapPath(string logPath) => (!logPath.StartsWith("\"") && logPath.Contains(" ")) ? $"\"{logPath}\"" : logPath;

--- a/RoboSharp/LoggingOptions.cs
+++ b/RoboSharp/LoggingOptions.cs
@@ -89,7 +89,7 @@ namespace RoboSharp
         /// Produce verbose output, showing skipped files.
         /// [V]
         /// </summary>
-        public virtual bool VerboseOutput { get; set; }
+        public virtual bool VerboseOutput { get; set; } = true;
         /// <summary>
         /// Include source file time stamps in the output.
         /// [/TS]

--- a/RoboSharp/NativeMethods.cs
+++ b/RoboSharp/NativeMethods.cs
@@ -31,8 +31,9 @@ namespace RoboSharp
         [DllImport("kernel32.dll")]
         static extern int ResumeThread(IntPtr hThread);
 
-        public static void Suspend(this Process process)
+        public static bool Suspend(this Process process)
         {
+            if (process.HasExited) return false;
             foreach (ProcessThread thread in process.Threads)
             {
                 var pOpenThread = OpenThread(ThreadAccess.SUSPEND_RESUME, false, (uint)thread.Id);
@@ -42,9 +43,11 @@ namespace RoboSharp
                 }
                 SuspendThread(pOpenThread);
             }
+            return true;
         }
-        public static void Resume(this Process process)
+        public static bool Resume(this Process process)
         {
+            if (process.HasExited) return false;
             foreach (ProcessThread thread in process.Threads)
             {
                 var pOpenThread = OpenThread(ThreadAccess.SUSPEND_RESUME, false, (uint)thread.Id);
@@ -54,6 +57,7 @@ namespace RoboSharp
                 }
                 ResumeThread(pOpenThread);
             }
+            return true;
         }
     }
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/RoboSharp/ObservableList.cs
+++ b/RoboSharp/ObservableList.cs
@@ -211,6 +211,7 @@ namespace System.Collections.Generic
         ///<inheritdoc cref="System.Collections.Generic.List{T}.AddRange(IEnumerable{T})"/>
         new public virtual void AddRange(IEnumerable<T> collection)
         {
+            if (collection == null || collection.Count() == 0) return;
             base.AddRange(collection);
             OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, collection.ToList()));
         }
@@ -232,6 +233,7 @@ namespace System.Collections.Generic
         ///<remarks> Generates <see cref="CollectionChanged"/> event for items that were added and items that were shifted ( Event is raised twice )</remarks>
         new public virtual void InsertRange(int index, IEnumerable<T> collection)
         {
+            if (collection == null || collection.Count() == 0) return;
             int i = index + collection.Count() < this.Count ? collection.Count() : this.Count - index;
             List<T> movedItems = base.GetRange(index, i);
             base.InsertRange(index, collection);

--- a/RoboSharp/Results/ProgressEstimator.cs
+++ b/RoboSharp/Results/ProgressEstimator.cs
@@ -279,7 +279,7 @@ namespace RoboSharp.Results
             return Task.Factory.StartNew(async () => 
                 {
                     DateTime LastUpdate = DateTime.Now;
-                    TimeSpan UpdatePeriod = new TimeSpan(0, 0, 0, 0, 125);
+                    TimeSpan UpdatePeriod = new TimeSpan(0, 0, 0, 0, 60);
                     bool DirAdded = false;
                     bool FileAdded = false;
 

--- a/RoboSharp/Results/ProgressEstimator.cs
+++ b/RoboSharp/Results/ProgressEstimator.cs
@@ -264,6 +264,7 @@ namespace RoboSharp.Results
         [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
         private void QueueByteCalc(ProcessedFileInfo file, WhereToAdd whereTo)
         {
+            if (file == null) return;
             BytesToAdd.Enqueue(new Tuple<ProcessedFileInfo, WhereToAdd>(file, whereTo));
         }
 
@@ -328,7 +329,7 @@ namespace RoboSharp.Results
                     }
                     PushUpdate(ref DirAdded, ref FileAdded, tmpDir, tmpByte, tmpFile);
 
-                }, CancelSource.Token, TaskCreationOptions.LongRunning, PriorityScheduler.BelowNormal).Unwrap();
+                }, CancelSource.Token, TaskCreationOptions.LongRunning, TaskScheduler.Current).Unwrap();
             
         }
 

--- a/RoboSharp/Results/ProgressEstimator.cs
+++ b/RoboSharp/Results/ProgressEstimator.cs
@@ -192,22 +192,22 @@ namespace RoboSharp.Results
             CopyOpStarted = false;
 
             // EXTRA FILES
-            if (currentFile.FileClass == Config.LogParsing_ExtraFile)
+            if (currentFile.FileClass.Equals(Config.LogParsing_ExtraFile, StringComparison.CurrentCultureIgnoreCase))
             {
                 QueueByteCalc(currentFile, WhereToAdd.Extra);
             }
             //MisMatch
-            else if (currentFile.FileClass == Config.LogParsing_MismatchFile)
+            else if (currentFile.FileClass.Equals(Config.LogParsing_MismatchFile, StringComparison.CurrentCultureIgnoreCase))
             {
                 QueueByteCalc(currentFile, WhereToAdd.MisMatch);
             }
             //Failed Files
-            else if (currentFile.FileClass == Config.LogParsing_FailedFile)
+            else if (currentFile.FileClass.Equals(Config.LogParsing_FailedFile, StringComparison.CurrentCultureIgnoreCase))
             {
                 QueueByteCalc(currentFile, WhereToAdd.Failed);
             }
             //Identical Files
-            else if (currentFile.FileClass == Config.LogParsing_SameFile)
+            else if (currentFile.FileClass.Equals(Config.LogParsing_SameFile, StringComparison.CurrentCultureIgnoreCase))
             {
                 QueueByteCalc(currentFile, WhereToAdd.Skipped);
                 CurrentFile = null;
@@ -217,7 +217,7 @@ namespace RoboSharp.Results
             else
             {
                 SkippingFile = CopyOperation;//Assume Skipped, adjusted when CopyProgress is updated
-                if (currentFile.FileClass == Config.LogParsing_NewFile)
+                if (currentFile.FileClass.Equals(Config.LogParsing_NewFile, StringComparison.CurrentCultureIgnoreCase))
                 {
                     //Special handling for 0kb files -> They won't get Progress update, but will be created
                     if (currentFile.Size == 0)
@@ -225,20 +225,27 @@ namespace RoboSharp.Results
                         QueueByteCalc(currentFile, WhereToAdd.Copied);
                         SkippingFile = false;
                     }
-                    else if (!CopyOperation)
+                    else if (!CopyOperation) //Workaround for ListOnly Operation
                     {
                         QueueByteCalc(currentFile, WhereToAdd.Copied);
                     }
                 }
-                else if (currentFile.FileClass == Config.LogParsing_OlderFile)
+                else if (!CopyOperation)
                 {
-                    if (!CopyOperation && !command.SelectionOptions.ExcludeNewer)
-                        QueueByteCalc(currentFile, WhereToAdd.Copied);
-                }
-                else if (currentFile.FileClass == Config.LogParsing_NewerFile)
-                {
-                    if (!CopyOperation && !command.SelectionOptions.ExcludeOlder)
-                        QueueByteCalc(currentFile, WhereToAdd.Copied);
+                    if (currentFile.FileClass.Equals(Config.LogParsing_OlderFile, StringComparison.CurrentCultureIgnoreCase))
+                    {
+                        if (command.SelectionOptions.ExcludeOlder)
+                            QueueByteCalc(currentFile, WhereToAdd.Skipped);
+                        else
+                            QueueByteCalc(currentFile, WhereToAdd.Copied);
+                    }
+                    else if (currentFile.FileClass.Equals(Config.LogParsing_NewerFile, StringComparison.CurrentCultureIgnoreCase))
+                    {
+                        if (command.SelectionOptions.ExcludeNewer)
+                            QueueByteCalc(currentFile, WhereToAdd.Skipped);
+                        else
+                            QueueByteCalc(currentFile, WhereToAdd.Copied);
+                    }
                 }
             }
         }

--- a/RoboSharp/Results/RoboCopyResultsList.cs
+++ b/RoboSharp/Results/RoboCopyResultsList.cs
@@ -15,7 +15,10 @@ namespace RoboSharp.Results
     /// <summary>
     /// Object used to represent results from multiple <see cref="RoboCommand"/>s. <br/>
     /// As <see cref="RoboCopyResults"/> are added to this object, it will update the Totals and Averages accordingly.<para/>
-    /// This object is derived from <see cref="List{T}"/>, where T = <see cref="RoboCopyResults"/>, and implements <see cref="INotifyCollectionChanged"/>
+    /// Implements:
+    /// <br/><see cref="IRoboCopyResultsList"/>
+    /// <br/><see cref="IList{RoboCopyResults}"/> where T = RoboCopyResults
+    /// <br/><see cref="INotifyCollectionChanged"/>
     /// </summary>
     /// <remarks>
     /// <see href="https://github.com/tjscience/RoboSharp/wiki/RoboCopyResultsList"/>
@@ -112,18 +115,23 @@ namespace RoboSharp.Results
         #region < Public Properties >
 
         /// <summary> Sum of all DirectoryStatistics objects </summary>
+        /// <remarks>Underlying value is Lazy{Statistic} object - Initial value not calculated until first request. </remarks>
         public IStatistic DirectoriesStatistic => Total_DirStatsField?.Value;
 
         /// <summary> Sum of all ByteStatistics objects </summary>
+        /// <remarks>Underlying value is Lazy{Statistic} object - Initial value not calculated until first request. </remarks>
         public IStatistic BytesStatistic => Total_ByteStatsField?.Value;
 
         /// <summary> Sum of all FileStatistics objects </summary>
+        /// <remarks>Underlying value is Lazy{Statistic} object - Initial value not calculated until first request. </remarks>
         public IStatistic FilesStatistic => Total_FileStatsField?.Value;
 
         /// <summary> Average of all SpeedStatistics objects </summary>
+        /// <remarks>Underlying value is Lazy{SpeedStatistic} object - Initial value not calculated until first request. </remarks>
         public ISpeedStatistic SpeedStatistic => Average_SpeedStatsField?.Value;
 
         /// <summary> Sum of all RoboCopyExitStatus objects </summary>
+        /// <remarks>Underlying value is Lazy object - Initial value not calculated until first request. </remarks>
         public IRoboCopyCombinedExitStatus Status => ExitStatusSummaryField?.Value;
 
         /// <summary> The Collection of RoboCopy Results. Add/Removal of <see cref="RoboCopyResults"/> objects must be performed through this object's methods, not on the list directly. </summary>

--- a/RoboSharp/Results/RoboQueueProgressEstimator.cs
+++ b/RoboSharp/Results/RoboQueueProgressEstimator.cs
@@ -144,7 +144,7 @@ namespace RoboSharp.Results
                 //After cancellation is requested, ensure the bag is emptied
                 BagClearOut(tmp, StatToAddTo, EventBag);
 
-            }, CS.Token, TaskCreationOptions.LongRunning, PriorityScheduler.BelowNormal).Unwrap();
+            }, CS.Token, TaskCreationOptions.LongRunning, TaskScheduler.Current).Unwrap();
             
             return TaskRef;
         }

--- a/RoboSharp/RetryOptions.cs
+++ b/RoboSharp/RetryOptions.cs
@@ -49,7 +49,7 @@ namespace RoboSharp
         /// Specifies the number of retries N on failed copies (default is 0).
         /// [/R:N]
         /// </summary>
-        public int RetryCount
+        public virtual int RetryCount
         {
             get { return retryCount; }
             set { retryCount = value; }
@@ -58,7 +58,7 @@ namespace RoboSharp
         /// Specifies the wait time N in seconds between retries (default is 30).
         /// [/W:N]
         /// </summary>
-        public int RetryWaitTime
+        public virtual int RetryWaitTime
         {
             get { return retryWaitTime; }
             set { retryWaitTime = value; }
@@ -67,12 +67,12 @@ namespace RoboSharp
         /// Saves RetryCount and RetryWaitTime in the Registry as default settings.
         /// [/REG]
         /// </summary>
-        public bool SaveToRegistry { get; set; }
+        public virtual bool SaveToRegistry { get; set; }
         /// <summary>
         /// Wait for sharenames to be defined.
         /// [/TBD]
         /// </summary>
-        public bool WaitForSharenames { get; set; }
+        public virtual bool WaitForSharenames { get; set; }
 
         internal string Parse()
         {

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -451,8 +451,6 @@ namespace RoboSharp
         private Task GetRoboCopyTask(Results.ResultsBuilder resultsBuilder, string domain = "", string username = "", string password = "")
         {
             if (process != null) throw new InvalidOperationException("Cannot start a new RoboCopy Process while this RoboCommand is already running.");
-            var tokenSource = new CancellationTokenSource();
-            CancellationToken cancellationToken = tokenSource.Token;
 
             isRunning = true;
             DateTime StartTime = DateTime.Now;
@@ -529,7 +527,7 @@ namespace RoboSharp
                    results = resultsBuilder.BuildResults(process?.ExitCode ?? -1);
                }
                Debugger.Instance.DebugMessage("RoboCopy process exited.");
-           }, cancellationToken, TaskCreationOptions.LongRunning, PriorityScheduler.BelowNormal).Unwrap();
+           }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Current).Unwrap();
 
             Task continueWithTask = backupTask.ContinueWith((continuation) => // this task always runs
             {

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -647,7 +647,7 @@ namespace RoboSharp
             if (data.IsNullOrWhiteSpace())
                 return;
 
-            if (data.EndsWith("%", StringComparison.Ordinal))
+            if (Regex.IsMatch(data, "^[0-9]+[.]?[0-9]*%", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnorePatternWhitespace))
             {
                 //Increment ProgressEstimator
                 if (data == "100%")

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -446,7 +446,7 @@ namespace RoboSharp
         /// <exception cref="InvalidOperationException"/>
         private Task GetRoboCopyTask(Results.ResultsBuilder resultsBuilder, string domain = "", string username = "", string password = "")
         {
-            if (process != null ) throw new InvalidOperationException("Cannot start a new RoboCopy Process while this RoboCommand is already running.");
+            if (process != null) throw new InvalidOperationException("Cannot start a new RoboCopy Process while this RoboCommand is already running.");
             var tokenSource = new CancellationTokenSource();
             CancellationToken cancellationToken = tokenSource.Token;
 
@@ -508,7 +508,7 @@ namespace RoboSharp
                //hasExited = false;
                //Setup the Wait Cancellation Token
                var WaitExitSource = new CancellationTokenSource();
-               process.Exited += (o,e) => Process_Exited(WaitExitSource);
+               process.Exited += (o, e) => Process_Exited(WaitExitSource);
                Debugger.Instance.DebugMessage("RoboCopy process started.");
                process.Start();
                process.BeginOutputReadLine();
@@ -521,7 +521,7 @@ namespace RoboSharp
                Debugger.Instance.DebugMessage("RoboCopy process exited.");
            }, cancellationToken, TaskCreationOptions.LongRunning, PriorityScheduler.BelowNormal).Unwrap();
 
-            Task continueWithTask = backupTask.ContinueWith( (continuation) => // this task always runs
+            Task continueWithTask = backupTask.ContinueWith((continuation) => // this task always runs
             {
                 tokenSource.Dispose(); tokenSource = null; // Dispose of the Cancellation Token
                 Stop(true); //Ensure process is disposed of - Sets IsRunning flags to false
@@ -554,7 +554,7 @@ namespace RoboSharp
 #pragma warning restore CS1573
         {
             //If currently running and this is called, clone the command, then run the save method against the clone.
-            if (process != null )
+            if (process != null)
             {
                 var cmd = this.Clone();
                 cmd.StopIfDisposing = true;
@@ -562,7 +562,7 @@ namespace RoboSharp
                 cmd.Dispose();
                 return;
             }
-            
+
             bool _QUIT = JobOptions.PreventCopyOperation;
             string _PATH = JobOptions.FilePath;
             bool _NODD = JobOptions.NoDestinationDirectory;

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -264,18 +264,17 @@ namespace RoboSharp
         /// <summary>Pause execution of the RoboCopy process when <see cref="IsPaused"/> == false</summary>
         public virtual void Pause()
         {
-            if (process != null && isPaused == false)
+            if (process != null && !process.HasExited && isPaused == false)
             {
                 Debugger.Instance.DebugMessage("RoboCommand execution paused.");
-                process.Suspend();
-                isPaused = true;
+                isPaused = process.Suspend();
             }
         }
 
         /// <summary>Resume execution of the RoboCopy process when <see cref="IsPaused"/> == true</summary>
         public virtual void Resume()
         {
-            if (process != null && isPaused == true)
+            if (process != null && !process.HasExited && isPaused == true)
             {
                 Debugger.Instance.DebugMessage("RoboCommand execution resumed.");
                 process.Resume();
@@ -545,7 +544,7 @@ namespace RoboSharp
                 //Raise event announcing results are available
                 if (!hasError && resultsBuilder != null)
                     OnCommandCompleted?.Invoke(this, new RoboCommandCompletedEventArgs(results, StartTime, DateTime.Now));
-            });
+            }, CancellationToken.None);
 
             return continueWithTask;
         }

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -291,15 +291,15 @@ namespace RoboSharp
             //If the removal of that check broke your application, please create a new issue thread on the repo.
             if (process != null)
             {
-                if (!process.HasExited)
+                if (!isCancelled && (!process?.HasExited ?? true))
                 {
-                    process.Kill();
+                    process?.Kill();
                     isCancelled = true;
                 }
                 //hasExited = true;
                 if (DisposeProcess)
                 {
-                    process.Dispose();
+                    process?.Dispose();
                     process = null;
                 }
             }
@@ -652,7 +652,6 @@ namespace RoboSharp
                     resultsBuilder?.AddFileCopied(currentFile);
                 else
                     resultsBuilder?.SetCopyOpStarted();
-                resultsBuilder?.SetCopyOpStarted();
 
                 // copy progress data -> Use the CurrentFile and CurrentDir from the ResultsBuilder
                 OnCopyProgressChanged?.Invoke(this,

--- a/RoboSharp/RoboQueue.cs
+++ b/RoboSharp/RoboQueue.cs
@@ -524,7 +524,7 @@ namespace RoboSharp
 
                 RunCompleted?.Invoke(this, new RoboQueueCompletedEventArgs(ListResultsObj, StartTime, DateTime.Now));
                 return (IRoboCopyResultsList)ListResultsObj.Clone();
-            }
+            }, CancellationToken.None
             );
             return ResultsTask;
         }
@@ -558,7 +558,7 @@ namespace RoboSharp
 
                 RunCompleted?.Invoke(this, new RoboQueueCompletedEventArgs(RunResultsObj, StartTime, DateTime.Now));
                 return (IRoboCopyResultsList)RunResultsObj.Clone();
-            }
+            }, CancellationToken.None
             );
             return ResultsTask;
         }
@@ -665,7 +665,7 @@ namespace RoboSharp
                     Debugger.Instance.DebugMessage("RoboQueue Task Completed");
                     TaskCancelSource?.Dispose();
                 }
-            });
+            }, CancellationToken.None);
 
             return ContinueWithTask;
         }

--- a/RoboSharp/RoboQueue.cs
+++ b/RoboSharp/RoboQueue.cs
@@ -19,6 +19,7 @@ namespace RoboSharp
     /// Contains a private List{RoboCommand} object with controlled methods for access to it.  <br/>
     /// Attempting to modify the list while <see cref="IsRunning"/> = true results in <see cref="ListAccessDeniedException"/> being thrown.
     /// <para/>Implements the following: <br/>
+    /// <see cref="IRoboQueue"/> <br/>
     /// <see cref="IEnumerable"/> -- Allow enumerating through the collection that is stored in a private list -- Also see <see cref="Commands"/> <br/>
     /// <see cref="INotifyCollectionChanged"/> -- Allow subscription to collection changes against the list <see cref="ObservableList{T}"/> <br/>
     /// <see cref="INotifyPropertyChanged"/> -- Most properties will trigger <see cref="PropertyChanged"/> events when updated.<br/>

--- a/RoboSharp/RoboQueue.cs
+++ b/RoboSharp/RoboQueue.cs
@@ -644,30 +644,30 @@ namespace RoboSharp
            }, cancellationToken, TaskCreationOptions.LongRunning, PriorityScheduler.BelowNormal).Unwrap();
 
             //Continuation Task return results to caller
-            Task ContinueWithTask = StartAll.ContinueWith( async (continuation) =>
-            {
-                Estimator?.CancelTasks();
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    //If cancellation was requested -> Issue the STOP command to all commands in the list
-                    Debugger.Instance.DebugMessage("RoboQueue Task Was Cancelled");
-                    await StopAllTask(TaskList);
-                }
-                else if(continuation.IsFaulted)
-                {
-                    Debugger.Instance.DebugMessage("RoboQueue Task Faulted");
-                    await StopAllTask(TaskList);
-                    throw continuation.Exception;
-                }
-                else
-                {
-                    Debugger.Instance.DebugMessage("RoboQueue Task Completed");
-                }
+            Task ContinueWithTask = StartAll.ContinueWith(async (continuation) =>
+           {
+               Estimator?.CancelTasks();
+               if (cancellationToken.IsCancellationRequested)
+               {
+                   //If cancellation was requested -> Issue the STOP command to all commands in the list
+                   Debugger.Instance.DebugMessage("RoboQueue Task Was Cancelled");
+                   await StopAllTask(TaskList);
+               }
+               else if (continuation.IsFaulted)
+               {
+                   Debugger.Instance.DebugMessage("RoboQueue Task Faulted");
+                   await StopAllTask(TaskList);
+                   throw continuation.Exception;
+               }
+               else
+               {
+                   Debugger.Instance.DebugMessage("RoboQueue Task Completed");
+               }
 
-                TaskCancelSource?.Dispose();
-                TaskCancelSource = null;
+               TaskCancelSource?.Dispose();
+               TaskCancelSource = null;
 
-            }, CancellationToken.None).Unwrap();
+           }, CancellationToken.None).Unwrap();
 
             return ContinueWithTask;
         }

--- a/RoboSharp/RoboQueue.cs
+++ b/RoboSharp/RoboQueue.cs
@@ -499,6 +499,7 @@ namespace RoboSharp
         /// <inheritdoc cref="StartJobs"/>
         public Task<IRoboCopyResultsList> StartAll_ListOnly(string domain = "", string username = "", string password = "")
         {
+            if (IsRunning) throw new InvalidOperationException("Cannot start a new RoboQueue Process while this RoboQueue is already running.");
             IsListOnlyRunning = true;
             ListOnlyCompleted = false;
 
@@ -536,6 +537,8 @@ namespace RoboSharp
         /// <inheritdoc cref="StartJobs"/>
         public Task<IRoboCopyResultsList> StartAll(string domain = "", string username = "", string password = "")
         {
+            if (IsRunning) throw new InvalidOperationException("Cannot start a new RoboQueue Process while this RoboQueue is already running.");
+
             IsCopyOperationRunning = true;
             CopyOperationCompleted = false;
 
@@ -575,7 +578,7 @@ namespace RoboSharp
         private Task StartJobs(string domain = "", string username = "", string password = "", bool ListOnlyMode = false)
         {
             Debugger.Instance.DebugMessage("Starting Parallel execution of RoboQueue");
-
+            
             TaskCancelSource = new CancellationTokenSource();
             CancellationToken cancellationToken = TaskCancelSource.Token;
             var SleepCancelToken = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken).Token;

--- a/RoboSharp/RoboQueue.cs
+++ b/RoboSharp/RoboQueue.cs
@@ -447,13 +447,13 @@ namespace RoboSharp
         /// Create a new instance of the <see cref="ListResults"/> object
         /// </summary>
         /// <returns>New instance of the <see cref="ListResults"/> list.</returns>
-        public RoboCopyResultsList GetListResults() => new RoboCopyResultsList(ListResults.Collection);
+        public RoboCopyResultsList GetListResults() => ListResults.Clone();
 
         /// <summary>
         /// Create a new instance of the <see cref="RunResults"/> object
         /// </summary>
         /// <returns>New instance of the <see cref="RunResults"/> list.</returns>
-        public RoboCopyResultsList GetRunResults() => new RoboCopyResultsList(RunResults.Collection);
+        public RoboCopyResultsList GetRunResults() => RunResults.Clone();
 
         /// <summary>
         /// Run <see cref="RoboCommand.Stop()"/> against all items in the list.

--- a/RoboSharp/RoboQueue.cs
+++ b/RoboSharp/RoboQueue.cs
@@ -432,6 +432,7 @@ namespace RoboSharp
 
         /// <summary>
         /// Occurs if the RoboQueue task is stopped due to an unhandled exception. Occurs instead of <see cref="RoboQueue.RunCompleted"/>
+        /// <br/> Also occurs if any of the RoboCommand objects raise <see cref="RoboCommand.TaskFaulted"/>
         /// </summary>
         public event UnhandledExceptionEventHandler TaskFaulted;
 
@@ -619,6 +620,7 @@ namespace RoboSharp
                    cmd.OnError += this.OnError;
                    cmd.OnFileProcessed += this.OnFileProcessed;
                    cmd.OnProgressEstimatorCreated += Cmd_OnProgressEstimatorCreated;
+                   cmd.TaskFaulted += TaskFaulted;
 
                    //Start the job
                    //Once the job ends, unsubscribe events

--- a/RoboSharp/RoboQueue.cs
+++ b/RoboSharp/RoboQueue.cs
@@ -656,10 +656,11 @@ namespace RoboSharp
                if (!cancellationToken.IsCancellationRequested)
                {
                    var tcs = new TaskCompletionSource<object>();
-                   cancellationToken.Register(() => tcs.TrySetResult(null));
+                   _ = cancellationToken.Register(() => tcs.TrySetResult(null));
                    _ = await Task.WhenAny(Task.WhenAll(TaskList.ToArray()), tcs.Task);
                }
-           }, cancellationToken, TaskCreationOptions.LongRunning, PriorityScheduler.BelowNormal).Unwrap();
+
+           }, cancellationToken, TaskCreationOptions.LongRunning, TaskScheduler.Current).Unwrap();
 
             //Continuation Task return results to caller
             Task ContinueWithTask = StartAll.ContinueWith(async (continuation) =>

--- a/RoboSharp/RoboSharpConfiguration.cs
+++ b/RoboSharp/RoboSharpConfiguration.cs
@@ -179,6 +179,16 @@ namespace RoboSharp
         }
         private string failedToken;
 
+        /// <summary>
+        /// Log Lines starting with this string indicate : File was excluded by <see cref="SelectionOptions.ExcludedFiles"/> filters
+        /// </summary>
+        public string LogParsing_FileExclusion
+        {
+            get { return fileExcludedToken ?? GetDefaultConfiguration().fileExcludedToken ?? "named"; } // TO DO: Needs Verification
+            set { fileExcludedToken = value; }
+        }
+        private string fileExcludedToken;
+
         #endregion
 
         #region < Directory Tokens >
@@ -213,6 +223,16 @@ namespace RoboSharp
         }
         private string existingDirToken;
 
+        /// <summary>
+        /// Log Lines starting with this string indicate : Folder was excluded by <see cref="SelectionOptions.ExcludedDirectories"/> filters
+        /// </summary>
+        public string LogParsing_DirectoryExclusion
+        {
+            get { return dirExcludedToken ?? GetDefaultConfiguration().dirExcludedToken ?? "named"; } // TO DO: Needs Verification
+            set { dirExcludedToken = value; }
+        }
+        private string dirExcludedToken;
+
         #endregion
 
         #endregion </ Tokens for Log Parsing >
@@ -235,24 +255,34 @@ namespace RoboSharp
         /// <inheritdoc cref="System.Diagnostics.ProcessStartInfo.StandardErrorEncoding" path="/summary"/>
         public System.Text.Encoding StandardErrorEncoding { get; set; } = System.Text.Encoding.GetEncoding(System.Globalization.CultureInfo.CurrentCulture.TextInfo.OEMCodePage);
 
+
+        private RoboSharpConfiguration defaultConfig = null;
         private RoboSharpConfiguration GetDefaultConfiguration()
         {
+            if (defaultConfig != null) return defaultConfig;
+
             // check for default with language Tag xx-YY (e.g. en-US)
             var currentLanguageTag = System.Globalization.CultureInfo.CurrentUICulture.IetfLanguageTag;
             if (defaultConfigurations.ContainsKey(currentLanguageTag))
-                return defaultConfigurations[currentLanguageTag];
-
-            // check for default with language Tag xx (e.g. en)
-            var match = Regex.Match(currentLanguageTag, @"^\w+", RegexOptions.Compiled);
-            if (match.Success)
             {
-                var currentMainLanguageTag = match.Value;
-                if (defaultConfigurations.ContainsKey(currentMainLanguageTag))
-                    return defaultConfigurations[currentMainLanguageTag];
+                defaultConfig = defaultConfigurations[currentLanguageTag];
+            }
+            else
+            {
+                // check for default with language Tag xx (e.g. en)
+                var match = Regex.Match(currentLanguageTag, @"^\w+", RegexOptions.Compiled);
+                if (match.Success)
+                {
+                    var currentMainLanguageTag = match.Value;
+                    if (defaultConfigurations.ContainsKey(currentMainLanguageTag))
+                    {
+                        defaultConfig = defaultConfigurations[currentMainLanguageTag];
+                    }
+                }
             }
 
             // no match, fallback to en
-            return defaultConfigurations["en"];
+            return defaultConfig ?? defaultConfigurations["en"];
         }
     }
 }

--- a/RoboSharp/RoboSharpConfiguration.cs
+++ b/RoboSharp/RoboSharpConfiguration.cs
@@ -124,7 +124,7 @@ namespace RoboSharp
         /// </summary>
         public string LogParsing_OlderFile
         {
-            get { return olderToken ?? GetDefaultConfiguration().olderToken ??  "Older"; }
+            get { return olderToken ?? GetDefaultConfiguration().olderToken ?? "Older"; }
             set { olderToken = value; }
         }
         private string olderToken;
@@ -188,7 +188,7 @@ namespace RoboSharp
         /// </summary>
         public string LogParsing_NewDir
         {
-            get { return newerDirToken ?? GetDefaultConfiguration().newerDirToken  ?? "New Dir"; }
+            get { return newerDirToken ?? GetDefaultConfiguration().newerDirToken ?? "New Dir"; }
             set { newerDirToken = value; }
         }
         private string newerDirToken;

--- a/RoboSharp/SelectionOptions.cs
+++ b/RoboSharp/SelectionOptions.cs
@@ -172,7 +172,7 @@ namespace RoboSharp
                 }
                 return RetString.Trim();
             }
-            set 
+            set
             {
                 excludedFiles.Clear();
                 if (value.IsNullOrWhiteSpace()) return;
@@ -410,7 +410,7 @@ namespace RoboSharp
             MinFileAge = MaxFileAge.ReplaceIfEmpty(options.MinFileAge);
             MaxLastAccessDate = MaxFileAge.ReplaceIfEmpty(options.MaxLastAccessDate);
             MinLastAccessDate = MaxFileAge.ReplaceIfEmpty(options.MinLastAccessDate);
-            
+
             //Bools
             OnlyCopyArchiveFiles |= options.OnlyCopyArchiveFiles;
             OnlyCopyArchiveFilesAndResetArchiveFlag |= options.OnlyCopyArchiveFilesAndResetArchiveFlag;

--- a/RoboSharp/SelectionOptions.cs
+++ b/RoboSharp/SelectionOptions.cs
@@ -129,24 +129,24 @@ namespace RoboSharp
         /// Copies only files for which the Archive attribute is set.
         /// [/A]
         /// </summary>
-        public bool OnlyCopyArchiveFiles { get; set; }
+        public virtual bool OnlyCopyArchiveFiles { get; set; }
         /// <summary>
         /// Copies only files for which the Archive attribute is set, and resets the Archive attribute.
         /// [/M]
         /// </summary>
-        public bool OnlyCopyArchiveFilesAndResetArchiveFlag { get; set; }
+        public virtual bool OnlyCopyArchiveFilesAndResetArchiveFlag { get; set; }
         /// <summary>
         /// This property should be set to a string consisting of all the attributes to include (eg. AH; RASHCNETO).
         /// Includes only files for which any of the specified attributes are set.
         /// [/IA:attributes]
         /// </summary>
-        public string IncludeAttributes { get; set; }
+        public virtual string IncludeAttributes { get; set; }
         /// <summary>
         /// This property should be set to a string consisting of all the attributes to exclude (eg. AH; RASHCNETO).
         /// Excludes files for which any of the specified attributes are set.
         /// [/XA:attributes]
         /// </summary>
-        public string ExcludeAttributes { get; set; }
+        public virtual string ExcludeAttributes { get; set; }
         /// <summary>
         /// Files should be separated by spaces.
         /// Excludes files that match the specified names or paths. Note that FileName can include wildcard characters (* and ?).
@@ -238,96 +238,96 @@ namespace RoboSharp
         /// Excludes changed files.
         /// [/XC]
         /// </summary>
-        public bool ExcludeChanged { get; set; }
+        public virtual bool ExcludeChanged { get; set; }
         /// <summary>
         /// Excludes newer files.
         /// [/XN]
         /// </summary>
-        public bool ExcludeNewer { get; set; }
+        public virtual bool ExcludeNewer { get; set; }
         /// <summary>
         /// Excludes older files.
         /// [/XO]
         /// </summary>
-        public bool ExcludeOlder { get; set; }
+        public virtual bool ExcludeOlder { get; set; }
         /// <summary>
         /// Excludes extra files and directories.
         /// [/XX]
         /// </summary>
-        public bool ExcludeExtra { get; set; }
+        public virtual bool ExcludeExtra { get; set; }
         /// <summary>
         /// Excludes lonely files and directories.
         /// [/XL]
         /// </summary>
-        public bool ExcludeLonely { get; set; }
+        public virtual bool ExcludeLonely { get; set; }
         /// <summary>
         /// Includes the same files.
         /// [/IS]
         /// </summary>
-        public bool IncludeSame { get; set; }
+        public virtual bool IncludeSame { get; set; }
         /// <summary>
         /// Includes tweaked files.
         /// [/IT]
         /// </summary>
-        public bool IncludeTweaked { get; set; }
+        public virtual bool IncludeTweaked { get; set; }
         /// <summary>
         /// Zero indicates that this feature is turned off.
         /// Specifies the maximum file size (to exclude files bigger than N bytes).
         /// [/MAX:N]
         /// </summary>
-        public long MaxFileSize { get; set; }
+        public virtual long MaxFileSize { get; set; }
         /// <summary>
         /// Zero indicates that this feature is turned off.
         /// Specifies the minimum file size (to exclude files smaller than N bytes).
         /// [/MIN:N]
         /// </summary>
-        public long MinFileSize { get; set; }
+        public virtual long MinFileSize { get; set; }
         /// <summary>
         /// Specifies the maximum file age (to exclude files older than N days or date).
         /// [/MAXAGE:N OR YYYYMMDD]
         /// </summary>
-        public string MaxFileAge { get; set; }
+        public virtual string MaxFileAge { get; set; }
         /// <summary>
         /// Specifies the minimum file age (exclude files newer than N days or date).
         /// [/MINAGE:N OR YYYYMMDD]
         /// </summary>
-        public string MinFileAge { get; set; }
+        public virtual string MinFileAge { get; set; }
         /// <summary>
         /// Specifies the maximum last access date (excludes files unused since Date).
         /// [/MAXLAD:YYYYMMDD]
         /// </summary>
-        public string MaxLastAccessDate { get; set; }
+        public virtual string MaxLastAccessDate { get; set; }
         /// <summary>
         /// Specifies the minimum last access date (excludes files used since N) If N is less 
         /// than 1900, N specifies the number of days. Otherwise, N specifies a date 
         /// in the format YYYYMMDD.
         /// [/MINLAD:N or YYYYMMDD]
         /// </summary>
-        public string MinLastAccessDate { get; set; }
+        public virtual string MinLastAccessDate { get; set; }
         /// <summary>
         /// Excludes junction points, which are normally included by default.
         /// [/XJ]
         /// </summary>
-        public bool ExcludeJunctionPoints { get; set; }
+        public virtual bool ExcludeJunctionPoints { get; set; }
         /// <summary>
         /// Assumes FAT file times (two-second precision).
         /// [/FFT]
         /// </summary>
-        public bool UseFatFileTimes { get; set; }
+        public virtual bool UseFatFileTimes { get; set; }
         /// <summary>
         /// Compensates for one-hour DST time differences.
         /// [/DST]
         /// </summary>
-        public bool CompensateForDstDifference { get; set; }
+        public virtual bool CompensateForDstDifference { get; set; }
         /// <summary>
         /// Excludes junction points for directories.
         /// [/XJD]
         /// </summary>
-        public bool ExcludeJunctionPointsForDirectories { get; set; }
+        public virtual bool ExcludeJunctionPointsForDirectories { get; set; }
         /// <summary>
         /// Excludes junction points for files.
         /// [/XJF]
         /// </summary>
-        public bool ExcludeJunctionPointsForFiles { get; set; }
+        public virtual bool ExcludeJunctionPointsForFiles { get; set; }
 
         #endregion Public Properties
 


### PR DESCRIPTION
These changes are to more easily accomodate using classes derived from RoboComand with the RoboQueue Object.

- Mark most Properties as abstract to allow consumers to override them if needed
- Mark the 'Start' methods in RoboCommand as virtual.
- Introduce 'ListOnly' start methods to RoboCommand
- RoboQueue updated to use more efficient ListOnly start method