### PR TITLE
Thread Optimizations

### DIFF
--- a/RoboSharp.BackupApp/JobHistoryExpander_SingleJob.xaml.cs
+++ b/RoboSharp.BackupApp/JobHistoryExpander_SingleJob.xaml.cs
@@ -79,16 +79,15 @@ namespace RoboSharp.BackupApp
             
             IsResultsListBound = true;
 
-            ShowResultsListSummary(null, new System.ComponentModel.PropertyChangedEventArgs(""));
+            // Initialize the values
             DirectoriesStatistic_PropertyChanged(null, null);
             FilesStatistic_PropertyChanged(null, null);
             BytesStatistic_PropertyChanged(null, null);
-            
-            ////Trigger List Update
-            DirStat.PropertyChanged += ShowResultsListSummary;
-            FileStat.PropertyChanged += ShowResultsListSummary;
-            ByteStat.PropertyChanged += ShowResultsListSummary;
 
+            //Update Summary Event
+            ShowResultsListSummary(null, new System.ComponentModel.PropertyChangedEventArgs(""));
+            list.CollectionChanged += (o,e) => ShowResultsListSummary(o, null);
+            
             ////Bind in case updates
             DirStat.PropertyChanged += DirectoriesStatistic_PropertyChanged;
             FileStat.PropertyChanged += FilesStatistic_PropertyChanged;
@@ -154,7 +153,7 @@ namespace RoboSharp.BackupApp
         /// </summary>
         private void ShowResultsListSummary(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            if (e == null || (e.PropertyName != "" && e.PropertyName != "Total")) return;
+            //if (e == null || (e.PropertyName != "" && e.PropertyName != "Total")) return;
             string NL = Environment.NewLine;
             if (ResultsList == null || ResultsList.Count == 0)
             {

--- a/RoboSharp.BackupApp/MainWindow.xaml
+++ b/RoboSharp.BackupApp/MainWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:av="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:local="clr-namespace:RoboSharp.BackupApp" mc:Ignorable="av" x:Class="RoboSharp.BackupApp.MainWindow"
-        Title="Backup App" Height="700" Width="750" ResizeMode="NoResize" >
+        Title="Backup App" Height="700" Width="750" ResizeMode="CanResizeWithGrip" MinWidth="750" MaxWidth="750" MinHeight="650" >
     <Grid IsSharedSizeScope="True">
         <TabControl SelectionChanged="TabControl_SelectionChanged">
             <TabItem Header="Options" x:Name="OptionsTab">
@@ -315,7 +315,7 @@
             <!-- Multi-Job Tab -->
             <TabItem x:Name="MultiJobProgressTab" Header="Multi-Job ( RoboQueue )">
                 <Grid Margin="5" Background="#FFE5E5E5">
-                    <ScrollViewer HorizontalAlignment="Stretch" Margin="5" VerticalAlignment="Stretch" >
+                    <ScrollViewer HorizontalAlignment="Stretch" Margin="5" VerticalAlignment="Stretch">
                         <StackPanel>
                             <!-- RoboQueue Panel -->
                             <Expander x:Name="MultiJobExpander_Jobs" Background="LightBlue" Header="RoboQueue" RenderTransformOrigin="0.5,0.5">

--- a/RoboSharp.BackupApp/MainWindow.xaml.cs
+++ b/RoboSharp.BackupApp/MainWindow.xaml.cs
@@ -8,6 +8,7 @@ using System.Windows.Input;
 using System.Collections.Generic;
 using Microsoft.Win32;
 using RoboSharp.Interfaces;
+using System.Diagnostics;
 
 namespace RoboSharp.BackupApp
 {
@@ -258,6 +259,7 @@ namespace RoboSharp.BackupApp
             ChkListOnly.IsChecked = copy.LoggingOptions.ListOnly;
         }
 
+        [DebuggerHidden()]
         void DebugMessage(object sender, Debugger.DebugMessageArgs e)
         {
             Console.WriteLine(e.Message);

--- a/RoboSharp/EventArgObjects/StatChangedEventArg.cs
+++ b/RoboSharp/EventArgObjects/StatChangedEventArg.cs
@@ -9,14 +9,33 @@ using RoboSharp.Interfaces;
 namespace RoboSharp.EventArgObjects
 {
     /// <summary>
-    /// EventArgs provided by <see cref="Statistic.PropertyChanged"/> and other Events generated from a <see cref="Statistic"/> object.
+    /// Interface helper for dealing with Statistic Event Args
+    /// </summary>
+    public interface IStatisticPropertyChangedEventArg
+    {
+        /// <inheritdoc cref="Statistic.Type"/>
+        Statistic.StatType StatType { get; }
+        
+        /// <summary>TRUE if of type <see cref="StatChangedEventArg"/>. Otherwise false.</summary>
+        bool Is_StatChangedEventArg { get; }
+
+        /// <summary>TRUE if of type <see cref="StatisticPropertyChangedEventArgs"/>. Otherwise false.</summary>
+        bool Is_StatisticPropertyChangedEventArgs { get; }
+        
+        /// <inheritdoc cref="PropertyChangedEventArgs.PropertyName"/>
+        string PropertyName { get; }
+        
+    }
+    
+    /// <summary>
+    /// EventArgs provided by <see cref="Statistic.StatChangedHandler"/> when any individual property gets modified.
     /// </summary>
     /// <remarks>
     /// Under most circumstances, the 'PropertyName' property will detail which parameter has been updated. <br/>
     /// When the Statistic object has multiple values change via a method call ( Reset / Add / Subtract methods ), then PropertyName will be String.Empty, indicating multiple values have changed. <br/>
     /// If this is the case, then the <see cref="StatChangedEventArg.NewValue"/>, <see cref="StatChangedEventArg.OldValue"/>, and <see cref="StatChangedEventArg.Difference"/> will report the value from the sender's <see cref="Statistic.Total"/> property.
     /// </remarks>
-    public class StatChangedEventArg : PropertyChangedEventArgs
+    public class StatChangedEventArg : PropertyChangedEventArgs, IStatisticPropertyChangedEventArg
     {
         private StatChangedEventArg() : base("") { }
         internal StatChangedEventArg(Statistic stat, long oldValue, long newValue, string PropertyName) : base(PropertyName)
@@ -43,5 +62,49 @@ namespace RoboSharp.EventArgObjects
         /// Result of NewValue - OldValue
         /// </summary>
         public long Difference => NewValue - OldValue;
+
+        bool IStatisticPropertyChangedEventArg.Is_StatChangedEventArg => true;
+
+        bool IStatisticPropertyChangedEventArg.Is_StatisticPropertyChangedEventArgs => false;
+    }
+
+    /// <summary>
+    /// EventArgs provided by <see cref="Statistic.PropertyChanged"/>
+    /// </summary>
+    /// <remarks>
+    /// Under most circumstances, the 'PropertyName' property will detail which parameter has been updated. <br/>
+    /// When the Statistic object has multiple values change via a method call ( Reset / Add / Subtract methods ), then PropertyName will be String.Empty, indicating multiple values have changed. <br/>
+    /// If this is the case, then the <see cref="StatChangedEventArg.NewValue"/>, <see cref="StatChangedEventArg.OldValue"/>, and <see cref="StatChangedEventArg.Difference"/> will report the value from the sender's <see cref="Statistic.Total"/> property.
+    /// </remarks>
+    public class StatisticPropertyChangedEventArgs : PropertyChangedEventArgs, IStatisticPropertyChangedEventArg
+    {
+        private StatisticPropertyChangedEventArgs() : base("") { }
+        internal StatisticPropertyChangedEventArgs(Statistic stat, Statistic oldValue, string PropertyName) : base(PropertyName)
+        {
+            //Sender = stat;
+            StatType = stat.Type;
+            OldValue = oldValue;
+            NewValue = stat.Clone();
+            Lazydifference = new Lazy<Statistic>(() => Statistic.Subtract(NewValue, OldValue));
+        }
+
+        /// <inheritdoc cref="Statistic.Type"/>
+        public Statistic.StatType StatType { get; }
+
+        /// <summary> Old Value of the object </summary>
+        public IStatistic OldValue { get; }
+
+        /// <summary> Current Value of the object </summary>
+        public IStatistic NewValue { get; }
+
+        /// <summary>
+        /// Result of NewValue - OldValue
+        /// </summary>
+        public IStatistic Difference => Lazydifference.Value;
+        private Lazy<Statistic> Lazydifference;
+
+        bool IStatisticPropertyChangedEventArg.Is_StatChangedEventArg => false;
+
+        bool IStatisticPropertyChangedEventArg.Is_StatisticPropertyChangedEventArgs => true;
     }
 }

--- a/RoboSharp/Interfaces/IRoboCopyResultsList.cs
+++ b/RoboSharp/Interfaces/IRoboCopyResultsList.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Text;
 using RoboSharp.Results;
@@ -15,7 +16,7 @@ namespace RoboSharp.Interfaces
     /// <remarks>
     /// <see href="https://github.com/tjscience/RoboSharp/wiki/IRoboCopyResultsList"/>
     /// </remarks>
-    public interface IRoboCopyResultsList : IEnumerable<RoboCopyResults>, ICloneable
+    public interface IRoboCopyResultsList : IEnumerable<RoboCopyResults>, ICloneable, INotifyCollectionChanged
     {
         #region < Properties >
 

--- a/RoboSharp/Interfaces/IStatistic.cs
+++ b/RoboSharp/Interfaces/IStatistic.cs
@@ -44,6 +44,9 @@ namespace RoboSharp.Interfaces
         /// <summary> Total Extra that exist in the Destination (but are missing from the Source)</summary>
         long Extras { get; }
 
+        /// <inheritdoc cref="Statistic.NonZeroValue"/>
+        bool NonZeroValue { get; }
+
         #endregion
 
         #region < Events >

--- a/RoboSharp/Results/ResultsBuilder.cs
+++ b/RoboSharp/Results/ResultsBuilder.cs
@@ -47,18 +47,6 @@ namespace RoboSharp.Results
         /// <inheritdoc cref="ProgressEstimator"/>
         internal ProgressEstimator Estimator { get; }
 
-        /// <inheritdoc cref="ProgressEstimator.AddDir(ProcessedFileInfo, bool)"/>
-        internal void AddDir(ProcessedFileInfo currentDir, bool CopyOperation) => Estimator.AddDir(currentDir, CopyOperation);
-
-        /// <inheritdoc cref="ProgressEstimator.AddFile(ProcessedFileInfo, bool)"/>
-        internal void AddFile(ProcessedFileInfo currentFile, bool CopyOperation) => Estimator.AddFile(currentFile, CopyOperation);
-
-        /// <inheritdoc cref="ProgressEstimator.AddFileCopied"/>
-        internal void AddFileCopied(ProcessedFileInfo currentFile) => Estimator.AddFileCopied(currentFile);
-
-        /// <inheritdoc cref="ProgressEstimator.SetCopyOpStarted"/>
-        internal void SetCopyOpStarted() => Estimator.SetCopyOpStarted();
-
         #endregion
 
         /// <summary>
@@ -69,7 +57,7 @@ namespace RoboSharp.Results
             if (output == null)
                 return;
 
-            if (Regex.IsMatch(output, @"^\s*[\d\.,]+%\s*$", RegexOptions.Compiled))
+            if (Regex.IsMatch(output, @"^\s*[\d\.,]+%\s*$", RegexOptions.Compiled)) //Ignore Progress Indicators
                 return;
 
             outputLines.Add(output);

--- a/RoboSharp/Results/RoboQueueProgressEstimator.cs
+++ b/RoboSharp/Results/RoboQueueProgressEstimator.cs
@@ -35,9 +35,9 @@ namespace RoboSharp.Results
 
         //ThreadSafe Bags/Queues
         private readonly ConcurrentBag<IStatistic> SubscribedStats = new ConcurrentBag<IStatistic>();
-        private readonly ConcurrentBag<StatChangedEventArg> FileBag = new ConcurrentBag<StatChangedEventArg>();
-        private readonly ConcurrentBag<StatChangedEventArg> DirBag = new ConcurrentBag<StatChangedEventArg>();
-        private readonly ConcurrentBag<StatChangedEventArg> ByteBag = new ConcurrentBag<StatChangedEventArg>();
+        private readonly ConcurrentBag<PropertyChangedEventArgs> FileBag = new ConcurrentBag<PropertyChangedEventArgs>();
+        private readonly ConcurrentBag<PropertyChangedEventArgs> DirBag = new ConcurrentBag<PropertyChangedEventArgs>();
+        private readonly ConcurrentBag<PropertyChangedEventArgs> ByteBag = new ConcurrentBag<PropertyChangedEventArgs>();
 
         //Stats
         private readonly Statistic DirStatField = new Statistic(Statistic.StatType.Directories, "Directory Stats Estimate");
@@ -125,7 +125,7 @@ namespace RoboSharp.Results
         private void StartAddingBytes() =>  AddStatTask(ref AddBytes, ByteStatsField, ByteBag, ref AddBytesCancelSource);
 
 
-        private Task AddStatTask(ref Task TaskRef, Statistic StatToAddTo, ConcurrentBag<StatChangedEventArg> EventBag, ref CancellationTokenSource CancelSource)
+        private Task AddStatTask(ref Task TaskRef, Statistic StatToAddTo, ConcurrentBag<PropertyChangedEventArgs> EventBag, ref CancellationTokenSource CancelSource)
         {
             if (TaskRef != null && TaskRef.Status <= TaskStatus.Running) return TaskRef; //Don't run if already running
 
@@ -150,7 +150,7 @@ namespace RoboSharp.Results
             return TaskRef;
         }
 
-        private void BagClearOut(Statistic Tmp, Statistic StatToAddTo, ConcurrentBag<StatChangedEventArg> EventBag)
+        private void BagClearOut(Statistic Tmp, Statistic StatToAddTo, ConcurrentBag<PropertyChangedEventArgs> EventBag)
         {
             DateTime incrementTimer = DateTime.Now;
             bool itemAdded = false;
@@ -182,9 +182,9 @@ namespace RoboSharp.Results
 
         #region < Event Binding for Auto-Updates ( Internal ) >
 
-        private void BindDirStat(object o, PropertyChangedEventArgs e) => DirBag.Add((StatChangedEventArg)e);
-        private void BindFileStat(object o, PropertyChangedEventArgs e) => FileBag.Add((StatChangedEventArg)e);
-        private void BindByteStat(object o, PropertyChangedEventArgs e) => ByteBag.Add((StatChangedEventArg)e);
+        private void BindDirStat(object o, PropertyChangedEventArgs e) => DirBag.Add(e);
+        private void BindFileStat(object o, PropertyChangedEventArgs e) => FileBag.Add(e);
+        private void BindByteStat(object o, PropertyChangedEventArgs e) => ByteBag.Add(e);
 
         /// <summary>
         /// Subscribe to the update events of a <see cref="ProgressEstimator"/> object

--- a/RoboSharp/Results/RoboQueueProgressEstimator.cs
+++ b/RoboSharp/Results/RoboQueueProgressEstimator.cs
@@ -135,6 +135,7 @@ namespace RoboSharp.Results
             TaskRef = Task.Factory.StartNew( async () =>
             {
                 Statistic tmp = new Statistic(type: StatToAddTo.Type);
+                tmp.EnablePropertyChangeEvent = false;
                 while (!CS.IsCancellationRequested)
                 {
                     BagClearOut(tmp, StatToAddTo, EventBag);

--- a/RoboSharp/Results/SpeedStatistic.cs
+++ b/RoboSharp/Results/SpeedStatistic.cs
@@ -337,11 +337,11 @@ namespace RoboSharp.Results
         {
             EnablePropertyChangeEvent = false;
             //BytesPerSec
-            long i = Divisor < 1 ? 0 : (long)Math.Round(Combined_BytesPerSec / Divisor, 3);
+            var i = Divisor < 1 ? 0 : Math.Round(Combined_BytesPerSec / Divisor, 3);
             bool TriggerBPS = BytesPerSec != i;
             BytesPerSec = i;
             //MegaBytes
-            i = Divisor < 1 ? 0 : (long)Math.Round(Combined_MegaBytesPerMin / Divisor, 3);
+            i = Divisor < 1 ? 0 : Math.Round(Combined_MegaBytesPerMin / Divisor, 3);
             bool TriggerMBPM = MegaBytesPerMin != i;
             MegaBytesPerMin = i;
             //Trigger Events

--- a/RoboSharp/Results/Statistic.cs
+++ b/RoboSharp/Results/Statistic.cs
@@ -580,7 +580,7 @@ namespace RoboSharp.Results
 #endif
         public void AddStatistic(IStatistic stat)
         {
-            if (stat.Type == this.Type) 
+            if (stat.Type == this.Type && stat.NonZeroValue) 
                 Add(stat.Total, stat.Copied, stat.Extras, stat.Failed, stat.Mismatch, stat.Skipped);
         }
 
@@ -716,7 +716,7 @@ namespace RoboSharp.Results
 #endif
         public void Subtract(IStatistic stat)
         {
-            if (stat.Type == this.Type)
+            if (stat.Type == this.Type && stat.NonZeroValue)
                 Add(-stat.Total, -stat.Copied, -stat.Extras, -stat.Failed, -stat.Mismatch, -stat.Skipped);
         }
 

--- a/RoboSharp/Results/Statistic.cs
+++ b/RoboSharp/Results/Statistic.cs
@@ -125,6 +125,11 @@ namespace RoboSharp.Results
         #region < Properties >
 
         /// <summary>
+        /// Checks all values and determines if any of them are != 0.
+        /// </summary>
+        public bool NonZeroValue => TotalField != 0 || CopiedField != 0 || SkippedField != 0 || MismatchField != 0 || FailedField != 0 || ExtrasField != 0;
+
+        /// <summary>
         /// Name of the Statistics Object
         /// </summary>
         public string Name

--- a/RoboSharp/Results/Statistic.cs
+++ b/RoboSharp/Results/Statistic.cs
@@ -47,6 +47,19 @@ namespace RoboSharp.Results
             ExtrasField = stat.Extras;
         }
 
+        /// <summary> Clone an existing Statistic object</summary>
+        internal  Statistic(StatType type, string name, long total, long copied, long skipped, long mismatch, long failed, long extras)
+        {
+            Type = type;
+            NameField = name;
+            TotalField = total;
+            CopiedField = copied;
+            SkippedField = skipped;
+            MismatchField = mismatch;
+            FailedField = failed;
+            ExtrasField = extras;
+        }
+
         /// <summary> Describe the Type of Statistics Object </summary>
         public enum StatType
         {
@@ -76,10 +89,17 @@ namespace RoboSharp.Results
 
         /// <summary> This toggle Enables/Disables firing the <see cref="PropertyChanged"/> Event to avoid firing it when doing multiple consecutive changes to the values </summary>
         internal bool EnablePropertyChangeEvent = true;
+        private bool PropertyChangedListener => EnablePropertyChangeEvent && PropertyChanged != null;
+        private bool Listener_TotalChanged => EnablePropertyChangeEvent && OnTotalChanged != null;
+        private bool Listener_CopiedChanged => EnablePropertyChangeEvent && OnCopiedChanged != null;
+        private bool Listener_SkippedChanged => EnablePropertyChangeEvent && OnSkippedChanged != null;
+        private bool Listener_MismatchChanged => EnablePropertyChangeEvent && OnMisMatchChanged != null;
+        private bool Listener_FailedChanged => EnablePropertyChangeEvent && OnFailedChanged != null;
+        private bool Listener_ExtrasChanged => EnablePropertyChangeEvent && OnExtrasChanged != null;
 
         /// <summary>
         /// This event will fire when the value of the statistic is updated via Adding / Subtracting methods. <br/>
-        /// Provides <see cref="StatChangedEventArg"/> object.
+        /// Provides <see cref="StatisticPropertyChangedEventArgs"/> object.
         /// </summary>
         /// <remarks>
         /// Allows use with both binding to controls and <see cref="ProgressEstimator"/> binding. <br/>
@@ -107,18 +127,6 @@ namespace RoboSharp.Results
 
         /// <summary> Occurs when the <see cref="Extras"/> Property is updated. </summary>
         public event StatChangedHandler OnExtrasChanged;
-
-#if !NET40
-        [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
-        private Lazy<StatChangedEventArg> PrepEventArgs(long OldValue, long NewValue, string PropertyName) => new Lazy<StatChangedEventArg>(() => new StatChangedEventArg(this, OldValue, NewValue, PropertyName));
-        
-        [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
-        private StatChangedEventArg ConditionalPrepEventArgs(long OldValue, long NewValue, string PropertyName) => !EnablePropertyChangeEvent || OldValue == NewValue ? null : new StatChangedEventArg(this, OldValue, NewValue, PropertyName);
-#else
-        private Lazy<StatChangedEventArg> PrepEventArgs(long OldValue, long NewValue, string PropertyName) => new Lazy<StatChangedEventArg>(() => new StatChangedEventArg(this, OldValue, NewValue, PropertyName));
-        private StatChangedEventArg ConditionalPrepEventArgs(long OldValue, long NewValue, string PropertyName) => !EnablePropertyChangeEvent || OldValue == NewValue ? null : new StatChangedEventArg(this, OldValue, NewValue, PropertyName);
-#endif
-
 
         #endregion
 
@@ -160,10 +168,10 @@ namespace RoboSharp.Results
                 {
                     var e = PrepEventArgs(TotalField, value, "Total");
                     TotalField = value;
-                    if (EnablePropertyChangeEvent)
+                    if (e != null)
                     {
-                        PropertyChanged?.Invoke(this, e.Value);
-                        OnTotalChanged?.Invoke(this, e.Value);
+                        PropertyChanged?.Invoke(this, e.Value.Item2);
+                        OnTotalChanged?.Invoke(this, e.Value.Item1);
                     }
                 }
             }
@@ -178,10 +186,10 @@ namespace RoboSharp.Results
                 {
                     var e = PrepEventArgs(CopiedField, value, "Copied");
                     CopiedField = value;
-                    if (EnablePropertyChangeEvent)
+                    if (e != null)
                     {
-                        PropertyChanged?.Invoke(this, e.Value);
-                        OnCopiedChanged?.Invoke(this, e.Value);
+                        PropertyChanged?.Invoke(this, e.Value.Item2);
+                        OnCopiedChanged?.Invoke(this, e.Value.Item1);
                     }
                 }
             }
@@ -196,10 +204,10 @@ namespace RoboSharp.Results
                 {
                     var e = PrepEventArgs(SkippedField, value, "Skipped");
                     SkippedField = value;
-                    if (EnablePropertyChangeEvent)
+                    if (e != null)
                     {
-                        PropertyChanged?.Invoke(this, e.Value);
-                        OnSkippedChanged?.Invoke(this, e.Value);
+                        PropertyChanged?.Invoke(this, e.Value.Item2);
+                        OnSkippedChanged?.Invoke(this, e.Value.Item1);
                     }
                 }
             }
@@ -214,10 +222,10 @@ namespace RoboSharp.Results
                 {
                     var e = PrepEventArgs(MismatchField, value, "Mismatch");
                     MismatchField = value;
-                    if (EnablePropertyChangeEvent)
+                    if (e != null)
                     {
-                        PropertyChanged?.Invoke(this, e.Value);
-                        OnMisMatchChanged?.Invoke(this, e.Value);
+                        PropertyChanged?.Invoke(this, e.Value.Item2);
+                        OnMisMatchChanged?.Invoke(this, e.Value.Item1);
                     }
                 }
             }
@@ -232,10 +240,10 @@ namespace RoboSharp.Results
                 {
                     var e = PrepEventArgs(FailedField, value, "Failed");
                     FailedField = value;
-                    if (EnablePropertyChangeEvent)
+                    if (e != null)
                     {
-                        PropertyChanged?.Invoke(this, e.Value);
-                        OnFailedChanged?.Invoke(this, e.Value);
+                        PropertyChanged?.Invoke(this, e.Value.Item2);
+                        OnFailedChanged?.Invoke(this, e.Value.Item1);
                     }
                 }
             }
@@ -250,10 +258,10 @@ namespace RoboSharp.Results
                 {
                     var e = PrepEventArgs(ExtrasField, value, "Extras");
                     ExtrasField = value;
-                    if (EnablePropertyChangeEvent)
+                    if (e != null)
                     {
-                        PropertyChanged?.Invoke(this, e.Value);
-                        OnExtrasChanged?.Invoke(this, e.Value);
+                        PropertyChanged?.Invoke(this, e.Value.Item2);
+                        OnExtrasChanged?.Invoke(this, e.Value.Item1);
                     }
                 }
             }
@@ -432,32 +440,32 @@ namespace RoboSharp.Results
         /// <summary>
         /// Reset all values to Zero ( 0 ) -- Used by <see cref="RoboCopyResultsList"/> for the properties
         /// </summary>
-#if !NET40
         [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
-#endif
         public void Reset()
         {
+            Statistic OriginalValues = PropertyChangedListener && NonZeroValue ? this.Clone() : null;
+
             //Total
-            var eTotal = ConditionalPrepEventArgs(TotalField, 0, "Total");
+            var eTotal = ConditionalPrepEventArgs(Listener_TotalChanged, TotalField, 0, "Total");
             TotalField = 0;
             //Copied
-            var eCopied = ConditionalPrepEventArgs(CopiedField, 0, "Copied");
+            var eCopied = ConditionalPrepEventArgs(Listener_CopiedChanged, CopiedField, 0, "Copied");
             CopiedField = 0;
             //Extras
-            var eExtras = ConditionalPrepEventArgs(ExtrasField, 0, "Extras");
+            var eExtras = ConditionalPrepEventArgs(Listener_ExtrasChanged, ExtrasField, 0, "Extras");
             ExtrasField = 0;
             //Failed
-            var eFailed = ConditionalPrepEventArgs(FailedField, 0, "Failed");
+            var eFailed = ConditionalPrepEventArgs(Listener_FailedChanged, FailedField, 0, "Failed");
             FailedField = 0;
             //Mismatch
-            var eMismatch = ConditionalPrepEventArgs( MismatchField, 0, "Mismatch");
+            var eMismatch = ConditionalPrepEventArgs(Listener_MismatchChanged, MismatchField, 0, "Mismatch");
             MismatchField = 0;
             //Skipped
-            var eSkipped = ConditionalPrepEventArgs(SkippedField, 0, "Skipped");
+            var eSkipped = ConditionalPrepEventArgs(Listener_SkippedChanged, SkippedField, 0, "Skipped");
             SkippedField = 0;
 
             //Trigger Events 
-            TriggerDeferredEvents(eTotal, eCopied, eExtras, eFailed, eMismatch, eSkipped);
+            TriggerDeferredEvents(OriginalValues, eTotal, eCopied, eExtras, eFailed, eMismatch, eSkipped);
         }
 
 
@@ -465,13 +473,36 @@ namespace RoboSharp.Results
 
         #region < Trigger Deferred Events >
 
-#if !NET40
+        /// <summary>
+        /// Prep Event Args for SETTERS of the properties
+        /// </summary>
         [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
-#endif
-        private void TriggerDeferredEvents(StatChangedEventArg eTotal, StatChangedEventArg eCopied, StatChangedEventArg eExtras, StatChangedEventArg eFailed, StatChangedEventArg eMismatch, StatChangedEventArg eSkipped)
+        private Lazy<Tuple<StatChangedEventArg, StatisticPropertyChangedEventArgs>> PrepEventArgs(long OldValue, long NewValue, string PropertyName)
+        {
+            if (!EnablePropertyChangeEvent) return null;
+            var old = this.Clone();
+            return new Lazy<Tuple<StatChangedEventArg, StatisticPropertyChangedEventArgs>>(() =>
+            {
+                StatChangedEventArg e1 = new StatChangedEventArg(this, OldValue, NewValue, PropertyName);
+                var e2 = new StatisticPropertyChangedEventArgs(this, old, PropertyName);
+                return new Tuple<StatChangedEventArg, StatisticPropertyChangedEventArgs>(e1, e2);
+            });
+        }
+
+        /// <summary>
+        /// Prep event args for the ADD and RESET methods
+        /// </summary>
+        [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
+        private StatChangedEventArg ConditionalPrepEventArgs(bool Listener, long OldValue, long NewValue, string PropertyName)=> !Listener || OldValue == NewValue ? null : new StatChangedEventArg(this, OldValue, NewValue, PropertyName);
+
+        /// <summary>
+        /// Raises the events that were deferred while item was object was still being calculated by ADD / RESET
+        /// </summary>
+        [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
+        private void TriggerDeferredEvents(Statistic OriginalValues, StatChangedEventArg eTotal, StatChangedEventArg eCopied, StatChangedEventArg eExtras, StatChangedEventArg eFailed, StatChangedEventArg eMismatch, StatChangedEventArg eSkipped)
         {
             //Perform Events
-            var i = 0;
+            int i = 0;
             if (eTotal != null)
             {
                 i = 1;
@@ -504,16 +535,18 @@ namespace RoboSharp.Results
             }
 
             //Trigger PropertyChangeEvent
-            switch (i)
+            if (OriginalValues != null)
             {
-                case 0: return;
-                case 1: PropertyChanged?.Invoke(this, eTotal); return;
-                case 2: PropertyChanged?.Invoke(this, eCopied); return;
-                case 4: PropertyChanged?.Invoke(this, eExtras); return;
-                case 8: PropertyChanged?.Invoke(this, eFailed); return;
-                case 16: PropertyChanged?.Invoke(this, eMismatch); return;
-                case 32: PropertyChanged?.Invoke(this, eSkipped); return;
-                default: PropertyChanged?.Invoke(this, new StatChangedEventArg(this, eTotal?.OldValue ?? 0, eTotal?.NewValue ?? 0, String.Empty)); return;
+                switch (i)
+                {
+                    case 1: PropertyChanged?.Invoke(this, new StatisticPropertyChangedEventArgs(this, OriginalValues, eTotal.PropertyName)); return;
+                    case 2: PropertyChanged?.Invoke(this, new StatisticPropertyChangedEventArgs(this, OriginalValues, eCopied.PropertyName)); return;
+                    case 4: PropertyChanged?.Invoke(this, new StatisticPropertyChangedEventArgs(this, OriginalValues, eExtras.PropertyName)); return;
+                    case 8: PropertyChanged?.Invoke(this, new StatisticPropertyChangedEventArgs(this, OriginalValues, eFailed.PropertyName)); return;
+                    case 16: PropertyChanged?.Invoke(this, new StatisticPropertyChangedEventArgs(this, OriginalValues, eMismatch.PropertyName)); return;
+                    case 32: PropertyChanged?.Invoke(this, new StatisticPropertyChangedEventArgs(this, OriginalValues, eSkipped.PropertyName)); return;
+                    default: PropertyChanged?.Invoke(this, new StatisticPropertyChangedEventArgs(this, OriginalValues, String.Empty)); return;
+                }
             }
         }
 
@@ -531,43 +564,45 @@ namespace RoboSharp.Results
         /// <param name="failed"></param>
         /// <param name="mismatch"></param>
         /// <param name="skipped"></param>
-#if !NET40
         [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
-#endif
         public void Add(long total = 0, long copied = 0, long extras = 0, long failed = 0, long mismatch = 0, long skipped = 0)
         {
+            //Store the original object values for the event args
+            Statistic originalValues = PropertyChangedListener ? this.Clone() : null;
+
             //Total
             long i = TotalField;
             TotalField += total;
-            var eTotal = ConditionalPrepEventArgs(i, TotalField, "Total");
+            var eTotal = ConditionalPrepEventArgs(Listener_TotalChanged, i, TotalField, "Total");
 
             //Copied
             i = CopiedField;
             CopiedField += copied;
-            var eCopied = ConditionalPrepEventArgs(i, CopiedField, "Copied");
+            var eCopied = ConditionalPrepEventArgs(Listener_CopiedChanged, i, CopiedField, "Copied");
 
             //Extras
             i = ExtrasField;
             ExtrasField += extras;
-            var eExtras = ConditionalPrepEventArgs(i, ExtrasField, "Extras");
+            var eExtras = ConditionalPrepEventArgs(Listener_ExtrasChanged, i, ExtrasField, "Extras");
 
             //Failed
             i = FailedField;
             FailedField += failed;
-            var eFailed = ConditionalPrepEventArgs(i, FailedField, "Failed");
+            var eFailed = ConditionalPrepEventArgs(Listener_FailedChanged, i, FailedField, "Failed");
 
             //Mismatch
             i = MismatchField;
             MismatchField += mismatch;
-            var eMismatch = ConditionalPrepEventArgs(i, MismatchField, "Mismatch");
+            var eMismatch = ConditionalPrepEventArgs(Listener_MismatchChanged, i, MismatchField, "Mismatch");
 
             //Skipped
             i = SkippedField;
             SkippedField += skipped;
-            var eSkipped = ConditionalPrepEventArgs(i, SkippedField, "Skipped");
+            var eSkipped = ConditionalPrepEventArgs(Listener_SkippedChanged, i, SkippedField, "Skipped");
 
             //Trigger Events 
-            TriggerDeferredEvents(eTotal, eCopied, eExtras, eFailed, eMismatch, eSkipped);
+            if (EnablePropertyChangeEvent)
+                TriggerDeferredEvents(originalValues, eTotal, eCopied, eExtras, eFailed, eMismatch, eSkipped);
         }
 
         /// <summary>
@@ -575,9 +610,7 @@ namespace RoboSharp.Results
         /// Events are defered until all the fields have been added together.
         /// </summary>
         /// <param name="stat">Statistics Item to add</param>
-#if !NET40
         [MethodImpl(methodImplOptions: MethodImplOptions.AggressiveInlining)]
-#endif
         public void AddStatistic(IStatistic stat)
         {
             if (stat.Type == this.Type && stat.NonZeroValue) 
@@ -618,32 +651,44 @@ namespace RoboSharp.Results
         /// <param name="eventArgs">Arg provided by either <see cref="PropertyChanged"/> or a Statistic's object's On*Changed events</param>
         public void AddStatistic(PropertyChangedEventArgs eventArgs)
         {
-            if (eventArgs.GetType() != typeof(StatChangedEventArg)) return;
-            var e = (StatChangedEventArg)eventArgs;
-            if (e.StatType == this.Type)
+            //Only process the args if of the proper type
+            var e = eventArgs as IStatisticPropertyChangedEventArg;
+            if (e == null) return;
+            
+            if (e.StatType != this.Type || (e.Is_StatisticPropertyChangedEventArgs && e.Is_StatChangedEventArg))
             {
+                // INVALID!
+            }
+            else if (e.Is_StatisticPropertyChangedEventArgs)
+            {
+                var e1 = (StatisticPropertyChangedEventArgs)eventArgs;
+                AddStatistic(e1.Difference);
+            }
+            else if (e.Is_StatChangedEventArg)
+            {
+                var e2 = (StatChangedEventArg)eventArgs;
                 switch (e.PropertyName)
                 {
                     case "": //String.Empty means all fields have changed
-                        AddStatistic(e.Sender);
+                        AddStatistic(e2.Sender);
                         break;
                     case "Copied":
-                        this.Copied += e.Difference;
+                        this.Copied += e2.Difference;
                         break;
                     case "Extras":
-                        this.Extras += e.Difference;
+                        this.Extras += e2.Difference;
                         break;
                     case "Failed":
-                        this.Failed += e.Difference;
+                        this.Failed += e2.Difference;
                         break;
                     case "Mismatch":
-                        this.Mismatch += e.Difference;
+                        this.Mismatch += e2.Difference;
                         break;
                     case "Skipped":
-                        this.Skipped += e.Difference;
+                        this.Skipped += e2.Difference;
                         break;
                     case "Total":
-                        this.Total += e.Difference;
+                        this.Total += e2.Difference;
                         break;
                 }
             }
@@ -732,9 +777,9 @@ namespace RoboSharp.Results
         #pragma warning restore CS1573
 
         /// <summary>
-        /// Add the results of the supplied Statistics objects to this Statistics object.
+        /// Subtract the results of the supplied Statistics objects to this Statistics object.
         /// </summary>
-        /// <param name="stats">Statistics Item to add</param>
+        /// <param name="stats">Statistics Item to subtract</param>
         public void Subtract(IEnumerable<IStatistic> stats)
         {
             foreach (Statistic stat in stats)
@@ -742,6 +787,17 @@ namespace RoboSharp.Results
                 EnablePropertyChangeEvent = stat == stats.Last();
                 Subtract(stat);
             }
+        }
+
+        /// <param name="MainStat">Statistics object to clone</param>
+        /// <param name="stats"><inheritdoc cref="Subtract(IStatistic)"/></param>
+        /// <returns>Clone of the <paramref name="MainStat"/> object with the <paramref name="stats"/> subtracted from it.</returns>
+        /// <inheritdoc cref="Subtract(IStatistic)"/>       
+        public static Statistic Subtract(IStatistic MainStat, IStatistic stats)
+        {
+            var ret = MainStat.Clone();
+            ret.Subtract(stats);
+            return ret;
         }
 
         #endregion Subtract

--- a/RoboSharp/RoboQueue.cs
+++ b/RoboSharp/RoboQueue.cs
@@ -749,7 +749,6 @@ namespace RoboSharp
 
                 if (disposing)
                 {
-                    // TODO: dispose managed state (managed objects)
                     Estimator?.UnBind();
 
                     //RoboCommand objects attach to a process, so must be in the 'unmanaged' section.
@@ -758,7 +757,6 @@ namespace RoboSharp
                     CommandList.Clear();
                 }
 
-                // TODO: set large fields to null
                 disposedValue = true;
             }
         }


### PR DESCRIPTION
@PCAssistSoftware I've been working on this all day, and at the moment I don't know how else it could be improved, without someone with much more experience threading applications taking a look at it. At the moment, I've done my best on it. 

The commits all have descriptions as to what changed. Please test it out. As far as I can tell, it should now be using less threads overall, but also it seems to no longer have the issue of lines being added to the log after cancellation occurs.
Note that the UI is still running its updates after cancellation occurs, I don't think anything can be done about that. 

I've rebuilt a large amount of ProgressEstimator to accomplish this, since that has the stat objects that were all pushing events to the UI, which I believe is the cause of the issue we were seeing. This update loop I'm sure can be improved upon, but I am unsure how exactly. But overall, it is much simpler and more 'inline' with when a line is output from the process.

Some other fixes are included here too, such as apparently 'EXTRAS' are not counted towards the 'TOTAL' of a statistic object.