### PR TITLE
XML Writer for RoboCommand and RoboQueue

### DIFF
--- a/RoboSharp/CopyOptions.cs
+++ b/RoboSharp/CopyOptions.cs
@@ -139,8 +139,10 @@ namespace RoboSharp
         /// Allows you to supply a set of files to copy or use wildcard characters (* or ?). <br/>
         /// JobOptions file saves these into the /IF (Include Files) section
         /// </summary>
+        [System.Xml.Serialization.XmlIgnore()]
         public IEnumerable<string> FileFilter
         {
+            //TODO: Modify to allow serialization
             get
             {
                 return fileFilter;

--- a/RoboSharp/Results/RoboQueueProgressEstimator.cs
+++ b/RoboSharp/Results/RoboQueueProgressEstimator.cs
@@ -237,7 +237,6 @@ namespace RoboSharp.Results
             {
                 if (disposing)
                 {
-                    // TODO: dispose managed state (managed objects)
                 }
 
                 //Cancel the tasks

--- a/RoboSharp/Results/RoboQueueProgressEstimator.cs
+++ b/RoboSharp/Results/RoboQueueProgressEstimator.cs
@@ -245,7 +245,6 @@ namespace RoboSharp.Results
             }
         }
 
-        // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
         ~RoboQueueProgressEstimator()
         {
             // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -560,6 +560,10 @@ namespace RoboSharp
             return continueWithTask;
         }
 
+        #endregion
+
+        #region < Save & Load Job Files >
+
         /// <summary>
         /// Save this RoboCommand's options to a new RoboCopyJob ( *.RCJ ) file. <br/>
         /// Note: This will not save the path submitted into <see cref="JobOptions.FilePath"/>.
@@ -605,7 +609,13 @@ namespace RoboSharp
             Exception e = null;
             try
             {
+#if DEBUG
+                //TODO: Convert XML writer to its own method
+                RoboSharpXML.SaveRoboCommand(this, path);
+                await Task.Delay(0);
+#else
                 await GetRoboCopyTask(null, domain, username, password); //This should take approximately 1-2 seconds at most
+#endif
             }
             catch (Exception Fault)
             {
@@ -623,8 +633,12 @@ namespace RoboSharp
             }
         }
 
+#if DEBUG
+        // TODO: Add Comments once in release mode & remove IF DEBUG
+        internal static RoboCommand LoadFromXML(string filepath) => RoboSharpXML.LoadRoboCommand(filepath);
+#endif
 
-        #endregion
+#endregion
 
         #region < Process Event Handlers >
 
@@ -750,9 +764,9 @@ namespace RoboSharp
             }
         }
 
-        #endregion
+#endregion
 
-        #region < Other Public Methods >
+#region < Other Public Methods >
 
         /// <inheritdoc cref="Results.RoboCopyResults"/>
         /// <returns>The RoboCopyResults object from the last run</returns>
@@ -813,9 +827,9 @@ namespace RoboSharp
             //this.StopIfDisposing |= ((IRoboCommand)jobFile).StopIfDisposing;
         }
 
-        #endregion
+#endregion
 
-        #region < IDisposable Implementation >
+#region < IDisposable Implementation >
 
         bool disposed = false;
 
@@ -859,6 +873,6 @@ namespace RoboSharp
             disposed = true;
         }
 
-        #endregion IDisposable Implementation
+#endregion IDisposable Implementation
     }
 }

--- a/RoboSharp/RoboSharpConfiguration.cs
+++ b/RoboSharp/RoboSharpConfiguration.cs
@@ -164,7 +164,7 @@ namespace RoboSharp
         /// </summary>
         public string LogParsing_MismatchFile
         {
-            get { return mismatchToken ?? GetDefaultConfiguration().mismatchToken ?? "*Mismatch"; } // TODO: Needs Verification
+            get { return mismatchToken ?? GetDefaultConfiguration().mismatchToken ?? "*Mismatch"; }
             set { mismatchToken = value; }
         }
         private string mismatchToken;
@@ -174,7 +174,7 @@ namespace RoboSharp
         /// </summary>
         public string LogParsing_FailedFile
         {
-            get { return failedToken ?? GetDefaultConfiguration().failedToken ?? "*Failed"; } // TODO: Needs Verification
+            get { return failedToken ?? GetDefaultConfiguration().failedToken ?? "*Failed"; }
             set { failedToken = value; }
         }
         private string failedToken;
@@ -184,7 +184,7 @@ namespace RoboSharp
         /// </summary>
         public string LogParsing_FileExclusion
         {
-            get { return fileExcludedToken ?? GetDefaultConfiguration().fileExcludedToken ?? "named"; } // TODO: Needs Verification
+            get { return fileExcludedToken ?? GetDefaultConfiguration().fileExcludedToken ?? "named"; }
             set { fileExcludedToken = value; }
         }
         private string fileExcludedToken;
@@ -298,7 +298,7 @@ namespace RoboSharp
         /// </summary>
         public string LogParsing_DirectoryExclusion
         {
-            get { return dirExcludedToken ?? GetDefaultConfiguration().dirExcludedToken ?? "named"; } // TODO: Needs Verification
+            get { return dirExcludedToken ?? GetDefaultConfiguration().dirExcludedToken ?? "named"; }
             set { dirExcludedToken = value; }
         }
         private string dirExcludedToken;

--- a/RoboSharp/XMLWriter.cs
+++ b/RoboSharp/XMLWriter.cs
@@ -80,7 +80,7 @@ namespace RoboSharp
         /// </summary>
         /// <param name="filePath">path to some XML file</param>
         /// <returns>new object if creation is successful, otherwise returns null.</returns>
-        public static T Deserialize<T>(string filePath) where T : class
+        private static T Deserialize<T>(string filePath) where T : class
         {
             var serializer = new XmlSerializer(typeof(T));
             //TODO: Check valid path

--- a/RoboSharp/XMLWriter.cs
+++ b/RoboSharp/XMLWriter.cs
@@ -1,0 +1,105 @@
+﻿#if DEBUG //TODO Remove IF DEBUG if this is released
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using RoboSharp.Interfaces;
+using System.IO;
+using System.Xml;
+using System.Xml.Serialization;
+
+namespace RoboSharp
+{
+    /// <summary>
+    /// Class to Serialize/Deserialize RoboCommand and RoboQueue Objects
+    /// </summary>
+    internal static class RoboSharpXML
+    {
+        //TODO: if made public, generate comments for the methods
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="command"></param>
+        /// <param name="filePath"></param>
+        public static void SaveRoboCommand(RoboCommand command, string filePath) => SerializeClass(command, filePath);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="queue"></param>
+        /// <param name="filePath"></param>
+        public static void SaveRoboQueue(RoboQueue queue, string filePath) => SerializeClass(queue, filePath);
+
+        private static void SerializeClass<T>(T obj, string filePath)
+        {
+            var serializer = new XmlSerializer(typeof(T));
+            //TODO: Check valid path
+            using (var fileWriter = new StreamWriter(filePath))
+            {
+                serializer.Serialize(fileWriter, obj);
+            }
+        }
+
+
+        /// <summary>
+        /// Loads an XML file into a new JobFile object
+        /// </summary>
+        /// <param name="filePath"><inheritdoc cref="LoadFile(string)"/></param>
+        /// <returns>new JobFile object creation is successful, otherwise returns null.</returns>
+        public static JobFile LoadJobFile(string filePath) 
+        {
+            var tmp = LoadFile(filePath);
+            return tmp == null ? null : new JobFile(LoadRoboCommand(filePath));
+        }
+
+        /// <summary>
+        /// Load an XML file into a new RoboCommand object
+        /// </summary>
+        /// <param name="filePath"><inheritdoc cref="LoadFile(string)"/></param>
+        /// <returns>new RoboCommand object creation is successful, otherwise returns null.</returns>
+        public static RoboCommand LoadRoboCommand(string filePath) => LoadFile(filePath);
+
+        /// <param name="filePath">path to some XML file</param>
+        /// <returns>new RoboCommand object creation is successful, otherwise returns null.</returns>
+        private static RoboCommand LoadFile(string filePath)
+        {
+            var serializer = new XmlSerializer(typeof(RoboCommand));
+            //TODO: Check valid path
+            using (var xmlReader = XmlReader.Create(filePath))
+            {
+                if (serializer.CanDeserialize(xmlReader))
+                {
+                    var obj = serializer.Deserialize(xmlReader) as RoboCommand;
+                    return obj;
+                }
+            }
+            return null; //If you get here, return null because deserialization failed
+        }
+
+        /// <summary>
+        /// Load an XML file into a new RoboQueue object
+        /// </summary>
+        /// <param name="filePath">path to some XML file</param>
+        /// <returns>new RoboCommand object creation is successful, otherwise returns null.</returns>
+        public static RoboQueue LoadRoboQueue(string filePath)
+        {
+            var serializer = new XmlSerializer(typeof(RoboQueue));
+            //TODO: Check valid path
+            using (var xmlReader = XmlReader.Create(filePath))
+            {
+                if (serializer.CanDeserialize(xmlReader))
+                {
+                    var obj = serializer.Deserialize(xmlReader) as RoboQueue;
+                    return obj;
+                }
+            }
+            return null; //If you get here, return null because deserialization failed
+        }
+
+    }
+}
+
+#endif

--- a/RoboSharp/XMLWriter.cs
+++ b/RoboSharp/XMLWriter.cs
@@ -63,37 +63,37 @@ namespace RoboSharp
         public static RoboCommand LoadRoboCommand(string filePath) => LoadFile(filePath);
 
         /// <param name="filePath">path to some XML file</param>
-        /// <returns>new RoboCommand object creation is successful, otherwise returns null.</returns>
+        /// <returns>new RoboCommand object if creation is successful, otherwise returns null.</returns>
         private static RoboCommand LoadFile(string filePath)
         {
-            var serializer = new XmlSerializer(typeof(RoboCommand));
-            //TODO: Check valid path
-            using (var xmlReader = XmlReader.Create(filePath))
-            {
-                if (serializer.CanDeserialize(xmlReader))
-                {
-                    var obj = serializer.Deserialize(xmlReader) as RoboCommand;
-                    return obj;
-                }
-            }
-            return null; //If you get here, return null because deserialization failed
+            return Deserialize<RoboCommand>(filePath);
         }
 
         /// <summary>
         /// Load an XML file into a new RoboQueue object
         /// </summary>
         /// <param name="filePath">path to some XML file</param>
-        /// <returns>new RoboCommand object creation is successful, otherwise returns null.</returns>
+        /// <returns>new RoboQueue object if creation is successful, otherwise returns null.</returns>
         public static RoboQueue LoadRoboQueue(string filePath)
         {
-            var serializer = new XmlSerializer(typeof(RoboQueue));
+            return Deserialize<RoboQueue>(filePath);
+        }
+
+        /// <summary>
+        /// Load an XML file into a new object
+        /// </summary>
+        /// <param name="filePath">path to some XML file</param>
+        /// <returns>new object if creation is successful, otherwise returns null.</returns>
+        public static T Deserialize<T>(string filePath) where T : class
+        {
+            var serializer = new XmlSerializer(typeof(T));
             //TODO: Check valid path
             using (var xmlReader = XmlReader.Create(filePath))
             {
                 if (serializer.CanDeserialize(xmlReader))
                 {
-                    var obj = serializer.Deserialize(xmlReader) as RoboQueue;
-                    return obj;
+                    var obj = serializer.Deserialize(xmlReader);
+                    return (T)obj;
                 }
             }
             return null; //If you get here, return null because deserialization failed

--- a/RoboSharp/XMLWriter.cs
+++ b/RoboSharp/XMLWriter.cs
@@ -47,24 +47,20 @@ namespace RoboSharp
         /// <summary>
         /// Loads an XML file into a new JobFile object
         /// </summary>
-        /// <param name="filePath"><inheritdoc cref="LoadFile(string)"/></param>
+        /// <param name="filePath"><inheritdoc cref="LoadRoboCommand(string)"/></param>
         /// <returns>new JobFile object creation is successful, otherwise returns null.</returns>
         public static JobFile LoadJobFile(string filePath) 
         {
-            var tmp = LoadFile(filePath);
-            return tmp == null ? null : new JobFile(LoadRoboCommand(filePath));
+            var tmp = LoadRoboCommand(filePath);
+            return tmp == null ? null : new JobFile(tmp);
         }
 
         /// <summary>
         /// Load an XML file into a new RoboCommand object
         /// </summary>
-        /// <param name="filePath"><inheritdoc cref="LoadFile(string)"/></param>
-        /// <returns>new RoboCommand object creation is successful, otherwise returns null.</returns>
-        public static RoboCommand LoadRoboCommand(string filePath) => LoadFile(filePath);
-
         /// <param name="filePath">path to some XML file</param>
-        /// <returns>new RoboCommand object if creation is successful, otherwise returns null.</returns>
-        private static RoboCommand LoadFile(string filePath)
+        /// <returns>new RoboCommand object creation is successful, otherwise returns null.</returns>
+        public static RoboCommand LoadRoboCommand(string filePath)
         {
             return Deserialize<RoboCommand>(filePath);
         }


### PR DESCRIPTION
@PCAssistSoftware - Regarding #153 - Since I've worked with the xml serializer in the past, I wrote up this very basic class to serialize RoboCommand and RoboQueue.

Theres a lot more work that needs to be done before this would get released, but I wanted to provide you a starting point to work on it. ( I can review it and chime in, but would rather not dedicate myself to this, as I have other pressing projects, and you are the one primarily requesting it.)

Currently, I had to tag the `CopyOptions.FileFilters` with `[XMLIgnore()]` to get it to serialize robocomand. I have not written anything for loading it yet. I also simply mocked in the xml writer call into the current 'Save Job' method within robocommand, which is then wrapped in `#IF DEBUG` to avoid accidentally releasing it. 

In Visual studio the 'Task List' can be seen on things to do (Duplicates show up due to multiple framework targets, so I just filtered down to Net45)

![image](https://user-images.githubusercontent.com/20431767/155321893-4ffd2322-f189-48da-9d14-2d1d12fa11df.png)

Here is the file that RoboCommand serializer spit out. It should deserialize fine, but I haven't tested it. 
[Test.zip](https://github.com/tjscience/RoboSharp/files/8124384/Test.zip)

Also, methods for RoboQueue will need to be written and tested.

