### PR TITLE
IRoboCommand & RoboQueue Fixes

### DIFF
--- a/RoboSharp.BackupApp/MainWindow.xaml.cs
+++ b/RoboSharp.BackupApp/MainWindow.xaml.cs
@@ -547,7 +547,7 @@ namespace RoboSharp.BackupApp
         /// <summary>
         /// Disable associated MultiJob_CommandProgressIndicator to window
         /// </summary>
-        private void RoboQueue_OnCommandCompleted(RoboCommand sender, RoboCommandCompletedEventArgs e)
+        private void RoboQueue_OnCommandCompleted(IRoboCommand sender, RoboCommandCompletedEventArgs e)
         {
             UpdateCommandsRunningBox();
             Dispatcher.Invoke(() =>
@@ -586,7 +586,7 @@ namespace RoboSharp.BackupApp
         /// <summary>
         /// Log the Error to the Errors expander
         /// </summary>
-        private void RoboQueue_OnError(RoboCommand sender, ErrorEventArgs e)
+        private void RoboQueue_OnError(IRoboCommand sender, ErrorEventArgs e)
         {
             Dispatcher.BeginInvoke((Action)(() =>
             {
@@ -602,7 +602,7 @@ namespace RoboSharp.BackupApp
         /// Occurs while a command is starting prior to Robocopy starting (for example, due to missing source location), but won't break the entire RoboQueue. 
         /// That single job will just not start, all others will.
         /// </remarks>
-        private void RoboQueue_OnCommandError(RoboCommand sender, CommandErrorEventArgs e)
+        private void RoboQueue_OnCommandError(IRoboCommand sender, CommandErrorEventArgs e)
         {
             btn_StartQueue(null, null); // Stop Everything
 

--- a/RoboSharp.BackupApp/MultiJob_CommandProgressIndicator.xaml.cs
+++ b/RoboSharp.BackupApp/MultiJob_CommandProgressIndicator.xaml.cs
@@ -13,6 +13,7 @@ using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
 using System.IO;
+using RoboSharp.Interfaces;
 
 namespace RoboSharp.BackupApp
 {
@@ -26,14 +27,14 @@ namespace RoboSharp.BackupApp
             InitializeComponent();
         }
 
-        public MultiJob_CommandProgressIndicator(RoboCommand cmd)
+        public MultiJob_CommandProgressIndicator(IRoboCommand cmd)
         {
             InitializeComponent();
             BindToCommand(cmd);
         }
 
 
-        public RoboCommand Command { get; private set; }
+        public IRoboCommand Command { get; private set; }
 
         public string JobName { 
             get => jobName;
@@ -77,7 +78,7 @@ namespace RoboSharp.BackupApp
         private List<string> OrderLog_2;
 
 
-        public void BindToCommand(RoboCommand cmd)
+        public void BindToCommand(IRoboCommand cmd)
         {
             Command = cmd;
             ListObjSetupComplete = false;

--- a/RoboSharp/EventArgObjects/RoboQueueCommandStartedEventArgs.cs
+++ b/RoboSharp/EventArgObjects/RoboQueueCommandStartedEventArgs.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using RoboSharp.Interfaces;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -11,12 +12,12 @@ namespace RoboSharp.EventArgObjects
     public class RoboQueueCommandStartedEventArgs : EventArgs
     {
         private RoboQueueCommandStartedEventArgs() : base() { }
-        internal RoboQueueCommandStartedEventArgs(RoboCommand cmd) : base() { Command = cmd; StartTime = DateTime.Now; }
+        internal RoboQueueCommandStartedEventArgs(IRoboCommand cmd) : base() { Command = cmd; StartTime = DateTime.Now; }
 
         /// <summary>
         /// Command that started.
         /// </summary>
-        public RoboCommand Command { get; }
+        public IRoboCommand Command { get; }
 
         /// <summary>
         /// Returns TRUE if the command's <see cref="RoboSharp.Results.ProgressEstimator"/> is available for binding

--- a/RoboSharp/Interfaces/IRoboCommand.cs
+++ b/RoboSharp/Interfaces/IRoboCommand.cs
@@ -76,6 +76,9 @@ namespace RoboSharp.Interfaces
         /// <inheritdoc cref="RoboCommand.OnProgressEstimatorCreated"/>
         event RoboCommand.ProgressUpdaterCreatedHandler OnProgressEstimatorCreated;
 
+        /// <inheritdoc cref="RoboCommand.TaskFaulted"/>
+        event System.UnhandledExceptionEventHandler TaskFaulted;
+
         #endregion Events
 
         #region Methods
@@ -91,6 +94,10 @@ namespace RoboSharp.Interfaces
 
         /// <inheritdoc cref="RoboCommand.Start_ListOnly(string, string, string)"/>
         Task Start_ListOnly(string domain = "", string username = "", string password = "");
+
+
+        /// <inheritdoc cref="RoboCommand.GetResults"/>
+        Results.RoboCopyResults GetResults();
 
         /// <inheritdoc cref="RoboCommand.Stop()"/>
         void Stop();

--- a/RoboSharp/JobFile.cs
+++ b/RoboSharp/JobFile.cs
@@ -276,6 +276,19 @@ namespace RoboSharp
             }
         }
 
+        event UnhandledExceptionEventHandler IRoboCommand.TaskFaulted
+        {
+            add
+            {
+                ((IRoboCommand)roboCommand).TaskFaulted += value;
+            }
+
+            remove
+            {
+                ((IRoboCommand)roboCommand).TaskFaulted -= value;
+            }
+        }
+
         #endregion
 
         #region < Properties >
@@ -337,6 +350,11 @@ namespace RoboSharp
         Task<RoboCopyResults> IRoboCommand.StartAsync(string domain, string username, string password)
         {
             return roboCommand.StartAsync_ListOnly();
+        }
+
+        RoboCopyResults IRoboCommand.GetResults()
+        {
+            return ((IRoboCommand)roboCommand).GetResults();
         }
         #endregion
 

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -241,32 +241,32 @@ namespace RoboSharp
         #region < Events >
 
         /// <summary>Handles <see cref="OnFileProcessed"/></summary>
-        public delegate void FileProcessedHandler(RoboCommand sender, FileProcessedEventArgs e);
+        public delegate void FileProcessedHandler(IRoboCommand sender, FileProcessedEventArgs e);
         /// <summary>Occurs each time a new item has started processing</summary>
         public event FileProcessedHandler OnFileProcessed;
 
         /// <summary>Handles <see cref="OnCommandError"/></summary>
-        public delegate void CommandErrorHandler(RoboCommand sender, CommandErrorEventArgs e);
+        public delegate void CommandErrorHandler(IRoboCommand sender, CommandErrorEventArgs e);
         /// <summary>Occurs when an error occurs while generating the command that prevents the RoboCopy process from starting.</summary>
         public event CommandErrorHandler OnCommandError;
 
         /// <summary>Handles <see cref="OnError"/></summary>
-        public delegate void ErrorHandler(RoboCommand sender, ErrorEventArgs e);
+        public delegate void ErrorHandler(IRoboCommand sender, ErrorEventArgs e);
         /// <summary>Occurs an error is detected by RoboCopy </summary>
         public event ErrorHandler OnError;
 
         /// <summary>Handles <see cref="OnCommandCompleted"/></summary>
-        public delegate void CommandCompletedHandler(RoboCommand sender, RoboCommandCompletedEventArgs e);
+        public delegate void CommandCompletedHandler(IRoboCommand sender, RoboCommandCompletedEventArgs e);
         /// <summary>Occurs when the RoboCopy process has finished executing and results are available.</summary>
         public event CommandCompletedHandler OnCommandCompleted;
 
         /// <summary>Handles <see cref="OnCopyProgressChanged"/></summary>
-        public delegate void CopyProgressHandler(RoboCommand sender, CopyProgressEventArgs e);
+        public delegate void CopyProgressHandler(IRoboCommand sender, CopyProgressEventArgs e);
         /// <summary>Occurs each time the current item's progress is updated</summary>
         public event CopyProgressHandler OnCopyProgressChanged;
 
         /// <summary>Handles <see cref="OnProgressEstimatorCreated"/></summary>
-        public delegate void ProgressUpdaterCreatedHandler(RoboCommand sender, ProgressEstimatorCreatedEventArgs e);
+        public delegate void ProgressUpdaterCreatedHandler(IRoboCommand sender, ProgressEstimatorCreatedEventArgs e);
         /// <summary>
         /// Occurs when a <see cref="Results.ProgressEstimator"/> is created during <see cref="Start"/>, allowing binding to occur within the event subscriber. <br/>
         /// This event will occur once per Start.

--- a/RoboSharp/RoboQueue.cs
+++ b/RoboSharp/RoboQueue.cs
@@ -16,14 +16,14 @@ using RoboSharp.Results;
 namespace RoboSharp
 {
     /// <summary>
-    /// Contains a private List{RoboCommand} object with controlled methods for access to it.  <br/>
+    /// Contains a private List{IRoboCommand} object with controlled methods for access to it.  <br/>
     /// Attempting to modify the list while <see cref="IsRunning"/> = true results in <see cref="ListAccessDeniedException"/> being thrown.
     /// <para/>Implements the following: <br/>
     /// <see cref="IRoboQueue"/> <br/>
     /// <see cref="IEnumerable"/> -- Allow enumerating through the collection that is stored in a private list -- Also see <see cref="Commands"/> <br/>
     /// <see cref="INotifyCollectionChanged"/> -- Allow subscription to collection changes against the list <see cref="ObservableList{T}"/> <br/>
     /// <see cref="INotifyPropertyChanged"/> -- Most properties will trigger <see cref="PropertyChanged"/> events when updated.<br/>
-    /// <see cref="IDisposable"/> -- Allow disposal of all <see cref="RoboCommand"/> objects in the list.
+    /// <see cref="IDisposable"/> -- Allow disposal of all <see cref="IRoboCommand"/> objects in the list.
     /// </summary>
     /// <remarks>
     /// <see href="https://github.com/tjscience/RoboSharp/wiki/RoboQueue"/>
@@ -52,10 +52,10 @@ namespace RoboSharp
         }
 
         /// <summary>
-        /// Initialize a new <see cref="RoboQueue"/> object that contains the supplied <see cref="RoboCommand"/>.
+        /// Initialize a new <see cref="RoboQueue"/> object that contains the supplied <see cref="IRoboCommand"/>.
         /// </summary>
         /// <inheritdoc cref="RoboQueue(IEnumerable{IRoboCommand}, string, int)"/>
-        public RoboQueue(RoboCommand roboCommand, string name = "", int maxConcurrentJobs = 1)
+        public RoboQueue(IRoboCommand roboCommand, string name = "", int maxConcurrentJobs = 1)
         {
             CommandList.Add(roboCommand);
             Init(name, maxConcurrentJobs);
@@ -63,9 +63,9 @@ namespace RoboSharp
         }
 
         /// <summary>
-        /// Initialize a new <see cref="RoboQueue"/> object that contains the supplied <see cref="RoboCommand"/> collection.
+        /// Initialize a new <see cref="RoboQueue"/> object that contains the supplied <see cref="IRoboCommand"/> collection.
         /// </summary>
-        /// <param name="roboCommand">RoboCommand(s) to populate the list with.</param>
+        /// <param name="roboCommand">IRoboCommand(s) to populate the list with.</param>
         /// <param name="name"><inheritdoc cref="Name"/></param>
         /// <param name="maxConcurrentJobs"><inheritdoc cref="MaxConcurrentJobs"/></param>
         public RoboQueue(IEnumerable<IRoboCommand> roboCommand, string name = "", int maxConcurrentJobs = 1)
@@ -108,19 +108,19 @@ namespace RoboSharp
         #region < Properties Dependent on CommandList >
 
         /// <summary> 
-        /// Checks <see cref="RoboCommand.IsRunning"/> property of all items in the list. 
+        /// Checks <see cref="IRoboCommand.IsRunning"/> property of all items in the list. 
         /// <br/> INotifyPropertyChanged is not raised when this property changes.
         /// </summary>
         public bool AnyRunning => CommandList.Any(c => c.IsRunning);
 
         /// <summary> 
-        /// Checks <see cref="RoboCommand.IsPaused"/> property of all items in the list. 
+        /// Checks <see cref="IRoboCommand.IsPaused"/> property of all items in the list. 
         /// <br/> INotifyPropertyChanged is not raised when this property changes.
         /// </summary>
         public bool AnyPaused => CommandList.Any(c => c.IsPaused);
 
         /// <summary> 
-        /// Checks <see cref="RoboCommand.IsCancelled"/> property of all items in the list. 
+        /// Checks <see cref="IRoboCommand.IsCancelled"/> property of all items in the list. 
         /// <br/> INotifyPropertyChanged is not raised when this property changes.
         /// </summary>
         public bool AnyCancelled => CommandList.Any(c => c.IsCancelled);
@@ -284,7 +284,7 @@ namespace RoboSharp
         }
 
         /// <summary>
-        /// Report how many <see cref="RoboCommand.Start"/> tasks has completed during the run. <br/>
+        /// Report how many <see cref="IRoboCommand.Start"/> tasks has completed during the run. <br/>
         /// This value is reset to 0 when a new run starts, and increments as each job exits.
         /// </summary>
         public int JobsComplete
@@ -301,7 +301,7 @@ namespace RoboSharp
         }
 
         /// <summary>
-        /// Report how many <see cref="RoboCommand.Start"/> tasks has completed successfully during the run. <br/>
+        /// Report how many <see cref="IRoboCommand.Start"/> tasks has completed successfully during the run. <br/>
         /// This value is reset to 0 when a new run starts, and increments as each job exits.
         /// </summary>
         public int JobsCompletedSuccessfully
@@ -318,7 +318,7 @@ namespace RoboSharp
         }
 
         /// <summary>
-        /// Report how many <see cref="RoboCommand.Start"/> tasks have been started during the run. <br/>
+        /// Report how many <see cref="IRoboCommand.Start"/> tasks have been started during the run. <br/>
         /// This value is reset to 0 when a new run starts, and increments as each job starts.
         /// </summary>
         public int JobsStarted
@@ -358,10 +358,10 @@ namespace RoboSharp
 
         #region < Events >
 
-        #region < RoboCommand Events  >
+        #region < IRoboCommand Events  >
 
         /// <inheritdoc cref="RoboCommand.OnFileProcessed"/>
-        /// <remarks>This bind to every RoboCommand in the list.</remarks>
+        /// <remarks>This bind to every IRoboCommand in the list.</remarks>
         public event RoboCommand.FileProcessedHandler OnFileProcessed;
 
         /// <inheritdoc cref="RoboCommand.OnCommandError"/>
@@ -461,8 +461,8 @@ namespace RoboSharp
             if (TaskCancelSource != null && !TaskCancelSource.IsCancellationRequested)
             {
                 IsPaused = false;
-                TaskCancelSource.Cancel(); // Cancel the RoboCommand Task
-                //RoboCommand Continuation Task will call StopAllTask() method to ensure all processes are stopped & diposed.
+                TaskCancelSource.Cancel(); // Cancel the IRoboCommand Task
+                //IRoboCommand Continuation Task will call StopAllTask() method to ensure all processes are stopped & diposed.
             }
             else if (TaskCancelSource == null)
             {
@@ -476,7 +476,7 @@ namespace RoboSharp
         }
 
         /// <summary>
-        /// Loop through the items in the list and issue <see cref="RoboCommand.Pause"/> on any commands where <see cref="RoboCommand.IsRunning"/> is true.
+        /// Loop through the items in the list and issue <see cref="IRoboCommand.Pause"/> on any commands where <see cref="IRoboCommand.IsRunning"/> is true.
         /// </summary>
         public void PauseAll()
         {
@@ -485,7 +485,7 @@ namespace RoboSharp
         }
 
         /// <summary>
-        /// Loop through the items in the list and issue <see cref="RoboCommand.Resume"/> on any commands where <see cref="RoboCommand.IsPaused"/> is true.
+        /// Loop through the items in the list and issue <see cref="IRoboCommand.Resume"/> on any commands where <see cref="IRoboCommand.IsPaused"/> is true.
         /// </summary>
         public void ResumeAll()
         {
@@ -498,7 +498,7 @@ namespace RoboSharp
         #region < Run List-Only Mode >
 
         /// <summary>
-        /// Set all RoboCommand objects to ListOnly mode, run them, then set all RoboCommands back to their previous ListOnly mode setting.
+        /// Set all IRoboCommand objects to ListOnly mode, run them, then set all RoboCommands back to their previous ListOnly mode setting.
         /// </summary>
         /// <inheritdoc cref="StartJobs"/>
         public Task<IRoboQueueResults> StartAll_ListOnly(string domain = "", string username = "", string password = "")
@@ -577,7 +577,7 @@ namespace RoboSharp
         /// <summary>
         /// Create Task that Starts all RoboCommands. 
         /// </summary>
-        /// <remarks> <paramref name="domain"/>, <paramref name="password"/>, and <paramref name="username"/> are applied to all RoboCommand objects during this run. </remarks>
+        /// <remarks> <paramref name="domain"/>, <paramref name="password"/>, and <paramref name="username"/> are applied to all IRoboCommand objects during this run. </remarks>
         /// <returns> New Task that finishes after all RoboCommands have stopped executing </returns>
         private Task StartJobs(string domain = "", string username = "", string password = "", bool ListOnlyMode = false)
         {
@@ -606,7 +606,7 @@ namespace RoboSharp
                OnProgressEstimatorCreated?.Invoke(this, new ProgressEstimatorCreatedEventArgs(Estimator));
 
                //Start all commands, running as many as allowed
-               foreach (RoboCommand cmd in CommandList)
+               foreach (IRoboCommand cmd in CommandList)
                {
                    if (cancellationToken.IsCancellationRequested) break;
 
@@ -702,16 +702,16 @@ namespace RoboSharp
             TaskCancelSource = null;
         }
 
-        private void Cmd_OnProgressEstimatorCreated(RoboCommand sender, ProgressEstimatorCreatedEventArgs e)
+        private void Cmd_OnProgressEstimatorCreated(IRoboCommand sender, ProgressEstimatorCreatedEventArgs e)
         {
             Estimator?.BindToProgressEstimator(e.ResultsEstimate);
             sender.OnProgressEstimatorCreated -= Cmd_OnProgressEstimatorCreated;
         }
 
         /// <summary>
-        /// Intercept OnCommandCompleted from each RoboCommand, react, then raise this object's OnCommandCompleted event
+        /// Intercept OnCommandCompleted from each IRoboCommand, react, then raise this object's OnCommandCompleted event
         /// </summary>
-        private void RaiseCommandCompleted(RoboCommand sender, RoboCommandCompletedEventArgs e, bool ListOnlyBinding)
+        private void RaiseCommandCompleted(IRoboCommand sender, RoboCommandCompletedEventArgs e, bool ListOnlyBinding)
         {
             if (ListOnlyBinding)
             {
@@ -746,8 +746,8 @@ namespace RoboSharp
                 {
                     Estimator?.UnBind();
 
-                    //RoboCommand objects attach to a process, so must be in the 'unmanaged' section.
-                    foreach (RoboCommand cmd in CommandList)
+                    //IRoboCommand objects attach to a process, so must be in the 'unmanaged' section.
+                    foreach (IRoboCommand cmd in CommandList)
                         cmd.Dispose();
                     CommandList.Clear();
                 }
@@ -757,7 +757,7 @@ namespace RoboSharp
         }
 
         /// <summary>
-        /// Finalizer -> Ensures that all RoboCommand objects get disposed of properly when program exits
+        /// Finalizer -> Ensures that all IRoboCommand objects get disposed of properly when program exits
         /// </summary>
         ~RoboQueue()
         {
@@ -766,7 +766,7 @@ namespace RoboSharp
         }
 
         /// <summary>
-        /// Dispose all RoboCommand objects contained in the list. - This will kill any Commands that have <see cref="RoboCommand.StopIfDisposing"/> = true (default) <br/>
+        /// Dispose all IRoboCommand objects contained in the list. - This will kill any Commands that have <see cref="RoboCommand.StopIfDisposing"/> = true (default) <br/>
         /// </summary>
         public void Dispose()
         {
@@ -824,7 +824,7 @@ namespace RoboSharp
 
         /// <inheritdoc cref="List{T}.Add(T)"/>
         /// <inheritdoc cref="ListAccessDeniedException.StandardMsg"/>
-        public void AddCommand(RoboCommand item)
+        public void AddCommand(IRoboCommand item)
         {
             if (IsRunning) throw new ListAccessDeniedException();
             CommandList.Add(item);
@@ -835,7 +835,7 @@ namespace RoboSharp
 
         /// <inheritdoc cref="List{T}.Insert(int, T)"/>
         /// <inheritdoc cref="ListAccessDeniedException.StandardMsg"/>
-        public void AddCommand(int index, RoboCommand item)
+        public void AddCommand(int index, IRoboCommand item)
         {
             if (IsRunning) throw new ListAccessDeniedException();
             CommandList.Insert(index, item);
@@ -859,7 +859,7 @@ namespace RoboSharp
 
         /// <inheritdoc cref="List{T}.Remove(T)"/>
         /// <inheritdoc cref="ListAccessDeniedException.StandardMsg"/>
-        public void RemoveCommand(RoboCommand item)
+        public void RemoveCommand(IRoboCommand item)
         {
             if (IsRunning) throw new ListAccessDeniedException();
             CommandList.Remove(item);
@@ -907,8 +907,8 @@ namespace RoboSharp
             OnPropertyChanged("Commands");
         }
 
-        /// <summary>Performs <see cref="RemoveCommand(int)"/> then <see cref="AddCommand(int, RoboCommand)"/></summary>
-        public void ReplaceCommand(RoboCommand item, int index)
+        /// <summary>Performs <see cref="RemoveCommand(int)"/> then <see cref="AddCommand(int, IRoboCommand)"/></summary>
+        public void ReplaceCommand(IRoboCommand item, int index)
         {
             if (IsRunning) throw new ListAccessDeniedException();
             CommandList.Replace(index, item);

--- a/RoboSharp/RoboSharp.csproj
+++ b/RoboSharp/RoboSharp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.2.7</Version>
+    <Version>1.2.8</Version>
     <Copyright>Copyright 2022</Copyright>
     <Authors>Terry</Authors>
     <owners>Terry</owners>


### PR DESCRIPTION
After the implementation of the factory method for RoboCommand objects, I realized that it required casting to work with the RoboQueue object. The casting was due to RoboQueue using RoboCommand and IRobocommand interchangably based on the writing process. Some methods called out RoboCommand, while the factory was producing IRoboCommands

This PR corrects that mistake to now use only IRoboCommand objects with RoboQueue.
This has the unfortunate side-effect of causing other objects to now also require passing out IRobocommand objects instead of RoboCommand objects, which arguably may be the correct thing to do since the events are also listed on the interface itself.

Update Version # to reflect significant changes ( Mainly that events are returning the  IRoboCommand objects instead of RoboCommand )


    
    
    