### PR TITLE
Update Net4.0

### DIFF
--- a/RoboSharp/ExtensionMethods.cs
+++ b/RoboSharp/ExtensionMethods.cs
@@ -22,9 +22,8 @@ namespace RoboSharp
 
         public static string CleanDirectoryPath(this string path)
         {
-            // Get rid of single and double quotes
-            path = path?.Replace("\"", "");
-            path = path?.Replace("\'", "");
+            // Get rid of leading/trailing for single and double quotes
+            path = path.Trim('\'', '\"');
 
             //Validate against null / empty strings. 
             if (string.IsNullOrWhiteSpace(path)) return string.Empty;


### PR DESCRIPTION
I ran into an issue where I tried to copy from folders that had a single quote in the folder name.  Current code fails to copy such files.  With this change, the files copy without issue.

I am updating the 4.0 NET branch because this is what I have to use in my software to maintain compatibility with legacy computers.