### PR TITLE
Fixed issue with paths containing single quotes within

### DIFF
--- a/RoboSharp/ExtensionMethods.cs
+++ b/RoboSharp/ExtensionMethods.cs
@@ -65,9 +65,8 @@ namespace RoboSharp
 
         public static string CleanDirectoryPath(this string path)
         {
-            // Get rid of single and double quotes
-            path = path?.Replace("\"", "");
-            path = path?.Replace("\'", "");
+            // Get rid of leading/trailing for single and double quotes
+            path = path.Trim('\'', '\"');
 
             //Validate against null / empty strings. 
             if (string.IsNullOrWhiteSpace(path)) return string.Empty;


### PR DESCRIPTION
Paths with single quotes within the path do not copy correctly. 

Example: C:\temp\Bob's Computer Barn\myBarn.txt will not copy.

