### PR TITLE
.NET 6.0 support, and fix for "1 is not a supported code page" error 

### DIFF
--- a/RoboSharp.BackupApp/App.config
+++ b/RoboSharp.BackupApp/App.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
     </startup>
 </configuration>

--- a/RoboSharp.BackupApp/RoboSharp.BackupApp.csproj
+++ b/RoboSharp.BackupApp/RoboSharp.BackupApp.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RoboSharp.BackupApp</RootNamespace>
     <AssemblyName>RoboSharp.BackupApp</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/RoboSharp.BackupApp/packages.config
+++ b/RoboSharp.BackupApp/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="TaskParallelLibrary" version="1.0.2856.0" targetFramework="net45" />
+  <package id="TaskParallelLibrary" version="1.0.2856.0" targetFramework="net452" />
 </packages>

--- a/RoboSharp/RoboSharp.csproj
+++ b/RoboSharp/RoboSharp.csproj
@@ -15,7 +15,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net40' Or '$(TargetFramework)' == 'net45'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net40' Or '$(TargetFramework)' == 'net452'">
     <Reference Include="System.Management" />
   </ItemGroup>
 

--- a/RoboSharp/RoboSharp.csproj
+++ b/RoboSharp/RoboSharp.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.2.8</Version>
-    <Copyright>Copyright 2022</Copyright>
+    <Version>1.2.9</Version>
+    <Copyright>Copyright 2023</Copyright>
     <Authors>Terry</Authors>
     <owners>Terry</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -12,9 +12,6 @@
     <PackageProjectUrl>https://github.com/tjscience/RoboSharp</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/tjscience/RoboSharp/master/robosharp.png</PackageIconUrl>
     <Description>RoboSharp is a .NET wrapper for the awesome Robocopy windows application.</Description>
-    <summary>
-      pull request #107
-    </summary>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
@@ -22,7 +19,7 @@
     <Reference Include="System.Management" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.Management.Infrastructure">
       <Version>2.0.0</Version>
     </PackageReference>

--- a/RoboSharp/RoboSharpConfiguration.cs
+++ b/RoboSharp/RoboSharpConfiguration.cs
@@ -332,12 +332,27 @@ namespace RoboSharp
 
         /// <Remarks>Default is retrieved from the OEMCodePage</Remarks>
         /// <inheritdoc cref="System.Diagnostics.ProcessStartInfo.StandardOutputEncoding" path="/summary"/>
-        public System.Text.Encoding StandardOutputEncoding { get; set; } = System.Text.Encoding.GetEncoding(System.Globalization.CultureInfo.CurrentCulture.TextInfo.OEMCodePage);
+        public System.Text.Encoding StandardOutputEncoding { get; set; } = GetEncoding();
 
         /// <Remarks>Default is retrieved from the OEMCodePage</Remarks>
         /// <inheritdoc cref="System.Diagnostics.ProcessStartInfo.StandardErrorEncoding" path="/summary"/>
-        public System.Text.Encoding StandardErrorEncoding { get; set; } = System.Text.Encoding.GetEncoding(System.Globalization.CultureInfo.CurrentCulture.TextInfo.OEMCodePage);
+        public System.Text.Encoding StandardErrorEncoding { get; set; } = GetEncoding();
 
+        static System.Text.Encoding GetEncoding()
+        {
+            try
+            {
+                return System.Text.Encoding.GetEncoding(System.Globalization.CultureInfo.CurrentCulture.TextInfo.OEMCodePage);
+            }
+            catch (ArgumentException)
+            {
+                return System.Text.Encoding.GetEncoding(437);
+            }
+            catch (NotSupportedException)
+            {
+                return System.Text.Encoding.GetEncoding(437);
+            }
+        }
 
         private RoboSharpConfiguration defaultConfig = null;
         private RoboSharpConfiguration GetDefaultConfiguration()


### PR DESCRIPTION
> Added target framework .NET 6.0

> Updated target framework from .NET Framework 4.5 to 4.5.2.  as developer pack for 4.5 is no longer available

> Handle "1 is not a supported code page" error when getting encoding for StandardOutputEncoding and StandardErrorEncoding

> Increment version

> Update copyright date