### PR TITLE
Fix for 163

### DIFF
--- a/RoboSharp/LoggingOptions.cs
+++ b/RoboSharp/LoggingOptions.cs
@@ -14,6 +14,19 @@ namespace RoboSharp
         #region Constructors 
 
         /// <summary>
+        /// The static constructor for the class to take care of any setup / fixes required before running any operations.
+        /// </summary>
+        static LoggingOptions()
+        {
+#if NETCOREAPP
+            // NetCoreApp and Net5 do not support encoding 437 by default, so we must register it to support .zip files.
+            //https://stackoverflow.com/questions/56802715/firefoxwebdriver-no-data-is-available-for-encoding-437/61203841#61203841
+            CodePagesEncodingProvider.Instance.GetEncoding(437);
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+#endif
+        }
+
+        /// <summary>
         /// Create new LoggingOptions with Default Settings
         /// </summary>
         public LoggingOptions() { }

--- a/RoboSharp/RoboSharp.csproj
+++ b/RoboSharp/RoboSharp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.2.9</Version>
+    <Version>1.3.0</Version>
     <Copyright>Copyright 2023</Copyright>
     <Authors>Terry</Authors>
     <owners>Terry</owners>


### PR DESCRIPTION
Fixes #163 - System.NotSupportedException: 'No data is available for encoding 437. For information on defining a custom encoding, see the documentation for the Encoding.RegisterProvider method.'

Increment version number as recent commits also include #170 support for .NET 6.0 authentication, using WindowsIdentity.RunImpersonated API, which is not supported on netstandard2.1 - and - Added PlatformNotSupportedException when trying to use authentication on unsupported target frameworks.