### PR TITLE
Fix CopyOptions.Compress Test

### DIFF
--- a/RoboSharp/ApplicationConstants.cs
+++ b/RoboSharp/ApplicationConstants.cs
@@ -1,9 +1,25 @@
 ﻿using System.Collections.Generic;
+using System.Text;
 
 namespace RoboSharp
 {
-    internal class ApplicationConstants
+    internal static class ApplicationConstants
     {
+
+        /// <summary>
+        /// The static constructor for the class to take care of any setup / fixes required before running any operations.
+        /// </summary>
+        static ApplicationConstants()
+        {
+#if NETCOREAPP // Ensure that encoding 437 is supported
+            CodePagesEncodingProvider.Instance.GetEncoding(437);
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+#endif
+        }
+
+        /// <summary> Request this null object used to ensure the static constructor executes </summary>
+        internal static object Initializer => null;
+
         internal static Dictionary<string, string> ErrorCodes = new Dictionary<string, string>()
         {
             { "ERROR 33 (0x00000021)", "The process cannot access the file because another process has locked a portion of the file." },

--- a/RoboSharp/GlobalSuppressions.cs
+++ b/RoboSharp/GlobalSuppressions.cs
@@ -9,3 +9,5 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Style", "IDE0066:Use 'switch expression(...)'", Justification = "Not compatible with C# 7.3 - NetStandard")]
 [assembly: SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Required by IList interface", Scope = "member", Target = "~M:RoboSharp.ImmutableList`1.Clear~RoboSharp.ImmutableList`1")]
 [assembly: SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Maintain compatibility with previous releases", Scope = "member", Target = "~M:RoboSharp.CopyOptions.CheckRunHoursString(System.String)~System.Boolean")]
+[assembly: SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "RoboCopy is a windows thing. Its not expected to run on other platforms.")]
+[assembly: SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "Valid code & easy to read")]

--- a/RoboSharp/LoggingOptions.cs
+++ b/RoboSharp/LoggingOptions.cs
@@ -13,18 +13,7 @@ namespace RoboSharp
     {
         #region Constructors 
 
-        /// <summary>
-        /// The static constructor for the class to take care of any setup / fixes required before running any operations.
-        /// </summary>
-        static LoggingOptions()
-        {
-#if NETCOREAPP
-            // NetCoreApp and Net5 do not support encoding 437 by default, so we must register it to support .zip files.
-            //https://stackoverflow.com/questions/56802715/firefoxwebdriver-no-data-is-available-for-encoding-437/61203841#61203841
-            CodePagesEncodingProvider.Instance.GetEncoding(437);
-            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-#endif
-        }
+        static LoggingOptions() { _ = ApplicationConstants.Initializer; }
 
         /// <summary>
         /// Create new LoggingOptions with Default Settings
@@ -267,7 +256,7 @@ namespace RoboSharp
         #endregion
 
         /// <summary> Encase the LogPath in quotes if needed </summary>
-        internal string WrapPath(string logPath) => (!logPath.StartsWith("\"") && logPath.Contains(" ")) ? $"\"{logPath}\"" : logPath;
+        internal static string WrapPath(string logPath) => (!logPath.StartsWith("\"") && logPath.Contains(" ")) ? $"\"{logPath}\"" : logPath;
 
         internal string Parse()
         {

--- a/RoboSharp/Results/Statistic.cs
+++ b/RoboSharp/Results/Statistic.cs
@@ -152,7 +152,7 @@ namespace RoboSharp.Results
                 if (value != NameField)
                 {
                     NameField = value ?? "";
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Name"));
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Name)));
                 }
             }
         }
@@ -622,9 +622,9 @@ namespace RoboSharp.Results
         }
 
         
-        #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
         /// <param name="enablePropertyChangedEvent"><inheritdoc cref="EnablePropertyChangeEvent" path="*"/></param>
-        /// <inheritdoc cref="AddStatistic(IStatistic)"/>        
+        /// <inheritdoc cref="AddStatistic(IStatistic)"/>
+        /// <param name="stats"/>
         internal void AddStatistic(IStatistic stats, bool enablePropertyChangedEvent)
         {
             EnablePropertyChangeEvent = enablePropertyChangedEvent;
@@ -632,8 +632,6 @@ namespace RoboSharp.Results
             EnablePropertyChangeEvent = true;
 
         }
-        #pragma warning restore CS1573
-
 
         /// <summary>
         /// Add the results of the supplied Statistics objects to this Statistics object.

--- a/RoboSharp/RoboSharp.csproj
+++ b/RoboSharp/RoboSharp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.3.1</Version>
+    <Version>1.3.2</Version>
     <Copyright>Copyright 2023</Copyright>
     <Authors>Terry</Authors>
     <owners>Terry</owners>

--- a/RoboSharp/RoboSharpConfiguration.cs
+++ b/RoboSharp/RoboSharpConfiguration.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 using System.Collections;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
@@ -14,18 +15,36 @@ namespace RoboSharp
     /// </remarks>
     public class RoboSharpConfiguration : ICloneable
     {
+        // Perform any preliminary library setup
+        static RoboSharpConfiguration()
+        {
+            // Perform any preliminary library setup
+            _ = ApplicationConstants.Initializer;
+            defaultConfigurations = new Dictionary<string, RoboSharpConfiguration>()
+            {
+                {"en", new RoboSharpConfig_EN() }, //en uses Defaults for LogParsing properties
+                {"de", new RoboSharpConfig_DE() },
+            };
+        }
+
+        private static readonly IDictionary<string, RoboSharpConfiguration> defaultConfigurations;
+
         #region Constructors 
 
         /// <summary>
         /// Create new LoggingOptions with Default Settings
         /// </summary>
-        public RoboSharpConfiguration() { }
+        public RoboSharpConfiguration() 
+        {
+            StandardErrorEncoding = GetEncoding();
+            StandardOutputEncoding = GetEncoding();
+        }
 
         /// <summary>
         /// Clone a RoboSharpConfiguration Object
         /// </summary>
         /// <param name="options">RoboSharpConfiguration object to clone</param>
-        public RoboSharpConfiguration(RoboSharpConfiguration options)
+        public RoboSharpConfiguration(RoboSharpConfiguration options) : this()
         {
             errorToken = options.errorToken;
             errorTokenRegex = options.errorTokenRegex;
@@ -55,13 +74,6 @@ namespace RoboSharp
         object ICloneable.Clone() => Clone();
 
         #endregion
-
-        private static readonly IDictionary<string, RoboSharpConfiguration>
-            defaultConfigurations = new Dictionary<string, RoboSharpConfiguration>()
-        {
-            {"en", new RoboSharpConfig_EN() }, //en uses Defaults for LogParsing properties
-            {"de", new RoboSharpConfig_DE() },
-        };
 
         /// <summary>
         /// Error Token Identifier -- EN = "ERROR", DE = "FEHLER", etc <br/>
@@ -116,7 +128,7 @@ namespace RoboSharp
             string pattern = BaseErrTokenRegex.ToString().Replace("IDENTIFIER", errorToken);
             return new Regex(pattern, BaseErrTokenRegex.Options);
         }
-        
+
 
         #region < Tokens for Log Parsing >
 
@@ -207,7 +219,7 @@ namespace RoboSharp
         /// </summary>
         public string LogParsing_AttribExclusion
         {
-            get { return attribExcludedToken ?? GetDefaultConfiguration().attribExcludedToken ?? "attrib"; } 
+            get { return attribExcludedToken ?? GetDefaultConfiguration().attribExcludedToken ?? "attrib"; }
             set { attribExcludedToken = value; }
         }
         private string attribExcludedToken;
@@ -217,7 +229,7 @@ namespace RoboSharp
         /// </summary>
         public string LogParsing_MaxFileSizeExclusion
         {
-            get { return maxfilesizeExcludedToken ?? GetDefaultConfiguration().maxfilesizeExcludedToken ?? "large"; } 
+            get { return maxfilesizeExcludedToken ?? GetDefaultConfiguration().maxfilesizeExcludedToken ?? "large"; }
             set { maxfilesizeExcludedToken = value; }
         }
         private string maxfilesizeExcludedToken;
@@ -227,7 +239,7 @@ namespace RoboSharp
         /// </summary>
         public string LogParsing_MinFileSizeExclusion
         {
-            get { return minfilesizeExcludedToken ?? GetDefaultConfiguration().minfilesizeExcludedToken ?? "small"; } 
+            get { return minfilesizeExcludedToken ?? GetDefaultConfiguration().minfilesizeExcludedToken ?? "small"; }
             set { minfilesizeExcludedToken = value; }
         }
         private string minfilesizeExcludedToken;
@@ -332,11 +344,11 @@ namespace RoboSharp
 
         /// <Remarks>Default is retrieved from the OEMCodePage</Remarks>
         /// <inheritdoc cref="System.Diagnostics.ProcessStartInfo.StandardOutputEncoding" path="/summary"/>
-        public System.Text.Encoding StandardOutputEncoding { get; set; } = GetEncoding();
+        public System.Text.Encoding StandardOutputEncoding { get; set; }
 
         /// <Remarks>Default is retrieved from the OEMCodePage</Remarks>
         /// <inheritdoc cref="System.Diagnostics.ProcessStartInfo.StandardErrorEncoding" path="/summary"/>
-        public System.Text.Encoding StandardErrorEncoding { get; set; } = GetEncoding();
+        public System.Text.Encoding StandardErrorEncoding { get; set; }
 
         static System.Text.Encoding GetEncoding()
         {
@@ -413,13 +425,13 @@ namespace RoboSharp
                 default:
                     throw new NotImplementedException(string.Format("{0} '{1}' Not Implemented!", nameof(ProcessedDirectoryFlag), status));
             }
-    }
+        }
 
-    /// <summary> Get the string representing the enum from the configuration </summary>
-    /// <param name="config">The configuration file to pull the log parsing string from</param>
-    /// <param name="status">The status to look up from the configuration</param>
-    /// <returns>The string from the config that is associated with this enum value</returns>
-    public static string GetFileClass(ProcessedFileFlag status, RoboSharpConfiguration config)
+        /// <summary> Get the string representing the enum from the configuration </summary>
+        /// <param name="config">The configuration file to pull the log parsing string from</param>
+        /// <param name="status">The status to look up from the configuration</param>
+        /// <returns>The string from the config that is associated with this enum value</returns>
+        public static string GetFileClass(ProcessedFileFlag status, RoboSharpConfiguration config)
         {
             if (config is null) throw new ArgumentNullException(nameof(config));
             switch (status)

--- a/RoboSharpUnitTesting/CopyOptionsTests.cs
+++ b/RoboSharpUnitTesting/CopyOptionsTests.cs
@@ -4,6 +4,7 @@ using RoboSharp.Results;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace RoboSharp.UnitTests
 {
@@ -182,13 +183,20 @@ namespace RoboSharp.UnitTests
                 Assert.IsTrue(opt.Compress);
                 Console.WriteLine("Current OS Version: " + Environment.OSVersion.VersionString);
 
+                CopyOptions.SetCanEnableCompression(false);
                 if (Environment.OSVersion.Version.Major >= 10 && Environment.OSVersion.Version.Build >= 19045)
                 {
                     // Dev PC where its /compress is known to be allowed
-                    CopyOptions.SetCanEnableCompression(false);
                     Assert.IsTrue(CopyOptions.TestCompressionFlag().Result);
                     Assert.IsTrue(CopyOptions.CanEnableCompression);
+                    Assert.IsTrue(new CopyOptions() { Compress = true }.Parse().ToLower().Contains("/compress"));
                 }
+                else
+                {
+                    // Unknown runner
+                    Assert.AreEqual(CopyOptions.TestCompressionFlag().Result, CopyOptions.CanEnableCompression);
+                }
+                Console.WriteLine("Compression Test - CanEnableCompression : " + CopyOptions.CanEnableCompression);
             }
             finally
             {

--- a/RoboSharpUnitTesting/GlobalSuppressions.cs
+++ b/RoboSharpUnitTesting/GlobalSuppressions.cs
@@ -1,0 +1,9 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Style", "IDE0063:Use simple 'using' statement", Justification = "Required by test", Scope = "member", Target = "~M:RoboSharp.UnitTests.RoboCommandEventTests.RoboCommand_OnError")]
+[assembly: SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "Required by test", Scope = "member", Target = "~M:RoboSharp.UnitTests.RoboCommandEventTests.RoboCommand_OnError")]

--- a/RoboSharpUnitTesting/ProgressEstimatorTests.cs
+++ b/RoboSharpUnitTesting/ProgressEstimatorTests.cs
@@ -1,9 +1,12 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RoboSharp;
+using RoboSharp.Interfaces;
 using RoboSharp.Results;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Text;
 
 namespace RoboSharp.UnitTests
 {
@@ -150,6 +153,37 @@ namespace RoboSharp.UnitTests
             File.SetLastAccessTime(filePath2, DateTime.Now);
         }
 
+
+        [DataRow(0)]
+        [DataRow(1)]
+        [DataRow(8)]
+        [TestMethod]
+        public void TestMultiThread(int threads)
+        {
+            RoboCommand cmd = Test_Setup.GenerateCommand(false, ListOnlyMode);
+            cmd.CopyOptions.MultiThreadedCopiesCount = threads;
+            Test_Setup.ClearOutTestDestination();
+            RoboSharpTestResults UnitTestResults = Test_Setup.RunTest(cmd).Result;
+            
+            // Ignore Directory Statistics during a multithread test, as they are not reported by robocopy
+            List<string> Errors = new List<string>();
+            RoboSharpTestResults.CompareStatistics(UnitTestResults.Results.FilesStatistic, UnitTestResults.Estimator.FilesStatistic, ref Errors);
+            RoboSharpTestResults.CompareStatistics(UnitTestResults.Results.BytesStatistic, UnitTestResults.Estimator.BytesStatistic, ref Errors);
+
+            Console.WriteLine("______ Files ______");
+            Console.WriteLine("  Command : " + UnitTestResults.Results.FilesStatistic);
+            Console.WriteLine("Estimator : " + UnitTestResults.Estimator.FilesStatistic);
+
+            Console.WriteLine("______ Bytes ______");
+            Console.WriteLine("  Command : " + UnitTestResults.Results.BytesStatistic);
+            Console.WriteLine("Estimator : " + UnitTestResults.Estimator.BytesStatistic);
+
+            var errTxt = new StringBuilder();
+            errTxt.Append("\n\n");
+            foreach (string st in Errors) errTxt.AppendLine(st);
+            Assert.IsFalse(Errors.Any(), errTxt.ToString());
+
+        }
 
         #region < Attribute Testing >
 

--- a/RoboSharpUnitTesting/ProgressEstimatorTests.cs
+++ b/RoboSharpUnitTesting/ProgressEstimatorTests.cs
@@ -182,8 +182,9 @@ namespace RoboSharp.UnitTests
         //[TestMethod] public void Test_ExcludeAttribEncrypted() => Test_Attributes(FileAttributes.Encrypted, false);
         [TestMethod] public void Test_ExcludeAttribTemporary() => Test_Attributes(FileAttributes.Temporary, false);
         [TestMethod] public void Test_ExcludeAttribOffline() => Test_Attributes(FileAttributes.Offline, false);
-        
 
+
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
         /// <param name="attributes"><inheritdoc cref="SelectionOptions.ConvertFileAttrToString(FileAttributes?)" path="*"/></param>
         /// <param name="Include">TRUE if setting to INCLUDE, False to EXCLUDE</param>
         private void Test_Attributes(FileAttributes attributes, bool Include)
@@ -237,7 +238,7 @@ namespace RoboSharp.UnitTests
             UnitTestResults.AssertTest();
             Assert.AreEqual(expectedFileCounts.Copied, UnitTestResults.Results.FilesStatistic.Copied);
         }
-
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
         #endregion
 
     }


### PR DESCRIPTION
I realized last night that the test I created to allow consumers to test if they can utilize /COMPRESS was flawed. It obeyed the safeguard instead of testing it. Resulting in potential false positives.

The new test bypasses the safeguard, as was initially intended.
This also increments the package version as to push out the updated test logic. 

I also verified that the ProgressEstimator was working properly with multithreaded settings, which I know used to not be the case. I guess all the thread-safety improvements I've done resolved that, but its now validated within a test.

Also, while testing this I was running into the Encoder(437) issues yet again. So I reworked that logic, primarily within the RoboSharpConfiguration, to ensure that the encoding is initialized prior to attempting to create the configurations that utilize it. ( Prior to this, the encodings were only initialized if creating a LoggingOptions object prior to a RoboSharpConfiguration object. That nuance is resolved here )