### PR TITLE
Update RoboQueueProgressEstimator.CancelTasks

### DIFF
--- a/RoboSharp.Extensions/RoboSharp.Extensions.csproj
+++ b/RoboSharp.Extensions/RoboSharp.Extensions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <TargetFrameworks>net452;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;</TargetFrameworks>
+      <TargetFrameworks>net452;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
       <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
       <Version>1.3.4</Version>
       <Copyright>Copyright 2023</Copyright>

--- a/RoboSharp.Extensions/RoboSharp.Extensions.csproj
+++ b/RoboSharp.Extensions/RoboSharp.Extensions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <TargetFrameworks>net452;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0;</TargetFrameworks>
+      <TargetFrameworks>net452;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;</TargetFrameworks>
       <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
       <Version>1.3.4</Version>
       <Copyright>Copyright 2023</Copyright>

--- a/RoboSharp/RoboQueue.cs
+++ b/RoboSharp/RoboQueue.cs
@@ -536,7 +536,7 @@ namespace RoboSharp
                     TaskFaulted?.Invoke(this, new UnhandledExceptionEventArgs(continuation.Exception, true));
                     throw continuation.Exception;
                 }
-                ListResultsObj.EndTime= DateTime.Now;
+                ListResultsObj.EndTime = DateTime.Now;
                 RunCompleted?.Invoke(this, new RoboQueueCompletedEventArgs(ListResultsObj, true));
                 return (IRoboQueueResults)ListResultsObj;
             }, CancellationToken.None
@@ -558,7 +558,7 @@ namespace RoboSharp
 
             RunResultsObj = new RoboQueueResults();
             RunResultsUpdated?.Invoke(this, new ResultListUpdatedEventArgs(RunResults));
-            
+
             Task Run = StartJobs(domain, username, password, false);
             Task<IRoboQueueResults> ResultsTask = Run.ContinueWith((continuation) =>
             {
@@ -610,7 +610,7 @@ namespace RoboSharp
             Task StartAll = Task.Factory.StartNew(async () =>
            {
                CommandList.RemoveAll((c) => c is null); // Remove all null references
-               
+
                //Reset results of all commands in the list
                foreach (RoboCommand cmd in CommandList.Where(cmd => cmd is RoboCommand).Select(cmd => (RoboCommand)cmd))
                    cmd?.ResetResults();
@@ -677,7 +677,7 @@ namespace RoboSharp
             //Continuation Task return results to caller
             Task ContinueWithTask = StartAll.ContinueWith(async (continuation) =>
            {
-               Estimator?.CancelTasks();
+               await Estimator?.CancelTasks();
                if (cancellationToken.IsCancellationRequested)
                {
                    //If cancellation was requested -> Issue the STOP command to all commands in the list
@@ -802,6 +802,13 @@ namespace RoboSharp
         {
             add { CommandList.CollectionChanged += value; }
             remove { CommandList.CollectionChanged -= value; }
+        }
+
+        /// <inheritdoc cref="IList.this"/>
+        public IRoboCommand this[int i]
+        {
+            get => this.CommandList[i];
+            set => this.CommandList[i] = value;
         }
 
         /// <summary>

--- a/RoboSharp/RoboSharp.csproj
+++ b/RoboSharp/RoboSharp.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.3.4</Version>
+    <Version>1.3.5</Version>
     <Copyright>Copyright 2023</Copyright>
     <Authors>Terry</Authors>
     <owners>Terry</owners>

--- a/RoboSharp/RoboSharp.csproj
+++ b/RoboSharp/RoboSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>1.3.4</Version>
     <Copyright>Copyright 2023</Copyright>


### PR DESCRIPTION

RE:  https://github.com/tjscience/RoboSharp/pull/183#issuecomment-1777920671

 - Should resolve issue with RoboQueueProgressEstimator.ValueUpdated firing after RoboQueue.RunCompleted


@PCAssistSoftware  I was bored in the hotel room, and I knew this would only take about 20 minutes or so. I think this should resolve your event order issue.
