### PR TITLE
Fix SpeedStatistic Parsing

### DIFF
--- a/RoboSharp/Results/SpeedStatistic.cs
+++ b/RoboSharp/Results/SpeedStatistic.cs
@@ -8,6 +8,7 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using RoboSharp.Interfaces;
 
+[assembly:InternalsVisibleTo("RoboSharp.UnitTests")]
 namespace RoboSharp.Results
 {
     /// <summary>
@@ -126,7 +127,7 @@ namespace RoboSharp.Results
         {
             var res = new SpeedStatistic();
 
-            var pattern = new Regex(@"\d+([\.,]\d+)?");
+            var pattern = new Regex(@"\d+([.,]\d+)+");
             Match match;
 
             match = pattern.Match(line1);

--- a/RoboSharp/Results/SpeedStatistic.cs
+++ b/RoboSharp/Results/SpeedStatistic.cs
@@ -75,7 +75,7 @@ namespace RoboSharp.Results
                 if (BytesPerSecField != value)
                 {
                     BytesPerSecField = value;
-                    if (EnablePropertyChangeEvent) OnPropertyChange("MegaBytesPerMin");
+                    if (EnablePropertyChangeEvent) OnPropertyChange(nameof(BytesPerSec));
                 }
             }
         }
@@ -89,7 +89,7 @@ namespace RoboSharp.Results
                 if (MegaBytesPerMinField != value)
                 {
                     MegaBytesPerMinField = value;
-                    if (EnablePropertyChangeEvent) OnPropertyChange("MegaBytesPerMin");
+                    if (EnablePropertyChangeEvent) OnPropertyChange(nameof(MegaBytesPerMin));
                 }
             }
         }

--- a/RoboSharp/Results/SpeedStatistic.cs
+++ b/RoboSharp/Results/SpeedStatistic.cs
@@ -132,13 +132,13 @@ namespace RoboSharp.Results
             match = pattern.Match(line1);
             if (match.Success)
             {
-                res.BytesPerSec = Convert.ToDecimal(match.Value.Replace(',', '.'), CultureInfo.InvariantCulture);
+                res.BytesPerSec = decimal.Parse(match.Value);
             }
 
             match = pattern.Match(line2);
             if (match.Success)
             {
-                res.MegaBytesPerMin = Convert.ToDecimal(match.Value.Replace(',', '.'), CultureInfo.InvariantCulture);
+                res.MegaBytesPerMin = decimal.Parse(match.Value);
             }
 
             return res;

--- a/RoboSharpUnitTesting/SpeedStatisticTests.cs
+++ b/RoboSharpUnitTesting/SpeedStatisticTests.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RoboSharp;
+using RoboSharp.Interfaces;
+using RoboSharp.Results;
+using RoboSharp.UnitTests;
+using System;
+using System.Text;
+
+namespace RoboSharp.UnitTests
+{
+    [TestClass]
+    public class SpeedStatisticTests
+    {
+        [TestMethod]
+        public void ParseTest()
+        {
+            string bps_string = " 538,252,733";
+            decimal bps = 538252733;
+
+            string mbpm_string = "30,799.068";
+            decimal mbpm = 30799.068m;
+
+            Console.Write("Validating Decimal.Parse()");
+            Assert.AreEqual(bps, decimal.Parse(bps_string), "\ndecimal parsing fails - bps");
+            Assert.AreEqual(mbpm, decimal.Parse(mbpm_string), "\ndecimal parsing fails - mbpm");
+            Console.WriteLine(" -- OK");
+
+            Console.Write("Validating SpeedStatistic.Parse()");
+            var stat = SpeedStatistic.Parse(bps_string, mbpm_string);
+            Assert.AreEqual(bps, stat.BytesPerSec, "\nBytes/second does not match!");
+            Assert.AreEqual(mbpm, stat.MegaBytesPerMin, "\nMegabytes/min does not match!");
+            Console.WriteLine(" -- OK");
+        }
+    }
+}


### PR DESCRIPTION
- Fix the Parsing of decimal values. Allow Decimal.Parse to handle the parsing, which uses the current culture by default and handles commas and periods.