### PR TITLE
Fix robo command ambiguity

### DIFF
--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -34,6 +34,13 @@ namespace RoboSharp
             Init();
         }
 
+        /// <inheritdoc cref="RoboCommand.RoboCommand(string, string, CopyActionFlags, SelectionFlags, LoggingFlags)"/>
+        public RoboCommand(string source, string destination, string name, CopyActionFlags copyActionFlags, SelectionFlags selectionFlags = SelectionFlags.Default, LoggingFlags loggingFlags = LoggingFlags.RoboSharpDefault)
+            :this(source, destination, copyActionFlags, selectionFlags, loggingFlags)
+        {
+            Name = name;
+        }
+
         /// <summary>
         /// Create a new RoboCommand object with the provided settings.
         /// </summary>
@@ -48,6 +55,9 @@ namespace RoboSharp
             this.selectionOptions.ApplySelectionFlags(selectionFlags);
             this.LoggingOptions.ApplyLoggingFlags(loggingFlags);
         }
+
+        /// <inheritdoc cref="Init"/>
+        public RoboCommand(string name) : this(string.Empty, string.Empty, name, stopIfDisposing: true) { }
 
         /// <inheritdoc cref="Init"/>
         public RoboCommand(string name, bool stopIfDisposing) : this(string.Empty, string.Empty, name, stopIfDisposing) { }

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -50,21 +50,19 @@ namespace RoboSharp
         }
 
         /// <inheritdoc cref="Init"/>
-        public RoboCommand(string name, bool stopIfDisposing = true)
-        {
-            InitClassProperties();
-            Init(name, stopIfDisposing);
-        }
+        public RoboCommand(string name, bool stopIfDisposing) : this(string.Empty, string.Empty, name, stopIfDisposing) { }
 
         /// <inheritdoc cref="Init"/>
-        public RoboCommand(string source, string destination, bool stopIfDisposing = true)
-        {
-            InitClassProperties();
-            Init("", stopIfDisposing, source, destination);
-        }
+        public RoboCommand(string source, string destination) : this(source, destination, string.Empty, stopIfDisposing: true) { }
 
         /// <inheritdoc cref="Init"/>
-        public RoboCommand(string source, string destination, string name, bool stopIfDisposing = true)
+        public RoboCommand(string source, string destination, bool stopIfDisposing) : this(source, destination, string.Empty, stopIfDisposing) { }
+
+        /// <inheritdoc cref="Init"/>
+        public RoboCommand(string source, string destination, string name) : this(source, destination, name, StopIfDisposing: true) { }
+
+        /// <inheritdoc cref="Init"/>
+        public RoboCommand(string source, string destination, string name, bool stopIfDisposing)
         {
             InitClassProperties();
             Init(name, stopIfDisposing, source, destination);


### PR DESCRIPTION
A long time ago, when I was a wee beginner, I added a flaw into the constructors of RoboCommand : Ambiguity.
This was primarily caused by the introduction of the 'stopIfDisposing' optional bool.

This PR adds several new constructor overloads for RoboCommand to allow the compilers to more easily find their 'best match' given the parameters. Overall functionality is unchanged, these overloads just ensure that a command that specifies source/destination has an exact matching constructor, instead of being ambiguous until you add a third parameter.
