### PR TITLE
Fix #178

### DIFF
--- a/RoboSharp.Extensions/Helpers/SelectionOptionsExtensions.cs
+++ b/RoboSharp.Extensions/Helpers/SelectionOptionsExtensions.cs
@@ -429,7 +429,7 @@ namespace RoboSharp.Extensions.Helpers
         /// <returns><see langword="true"/> if any of the regex items in the <paramref name="exclusionCollection"/> match the filename, otherwise false</returns>
         public static bool ShouldExcludeFileName(this SelectionOptions options, string fileName, IEnumerable<Regex> exclusionCollection = null)
         {
-            if (exclusionCollection is null) exclusionCollection = options.GetExcludedFileRegex();
+            exclusionCollection ??= options.GetExcludedFileRegex();
             if (!exclusionCollection.Any()) return false;
             string fname = Path.GetFileName(fileName);
             return exclusionCollection.Any(r => r.IsMatch(fname));
@@ -479,7 +479,7 @@ namespace RoboSharp.Extensions.Helpers
         /// <returns></returns>
         public static bool ShouldExcludeDirectoryName(this SelectionOptions options, string directoryPath, IEnumerable<Helpers.DirectoryRegex> exclusionCollection = null)
         {
-            if (exclusionCollection is null) exclusionCollection = options.GetExcludedDirectoryRegex();
+            exclusionCollection ??= options.GetExcludedDirectoryRegex();
             if (exclusionCollection.None()) return false;
             return exclusionCollection.Any(ob => ob.ShouldExcludeDirectory(directoryPath));
         }
@@ -531,7 +531,11 @@ namespace RoboSharp.Extensions.Helpers
         {
             if (!Directory.Exists(directory)) return true;
             if (options.ExcludeJunctionPoints | options.ExcludeJunctionPointsForDirectories)
+#if NET6_0_OR_GREATER
+                return new DirectoryInfo(directory).IsSymbolicLink();
+#else
                 return SymbolicLink.IsJunctionOrSymbolic(directory);
+#endif
             else
                 return false;
         }
@@ -541,7 +545,7 @@ namespace RoboSharp.Extensions.Helpers
         {
             if (!directory.Exists) return true;
             if (options.ExcludeJunctionPoints | options.ExcludeJunctionPointsForDirectories)
-                return SymbolicLink.IsJunctionOrSymbolic(directory.FullName);
+                return directory.IsSymbolicLink();// SymbolicLink.IsJunctionOrSymbolic(directory.FullName);
             else
                 return false;
         }
@@ -549,7 +553,7 @@ namespace RoboSharp.Extensions.Helpers
         /// <inheritdoc cref="ShouldExcludeJunctionDirectory(SelectionOptions, string)"/>
         public static bool ShouldExcludeJunctionDirectory(this SelectionOptions options, IDirectoryPair pair) => ShouldExcludeJunctionDirectory(options, pair.Source);
 
-        #endregion
+#endregion
 
     }
 }

--- a/RoboSharp.Extensions/RoboSharp.Extensions.csproj
+++ b/RoboSharp.Extensions/RoboSharp.Extensions.csproj
@@ -24,6 +24,9 @@
       <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'netstandard2.0'">
+      <langversion>8.0</langversion>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\RoboSharp\RoboSharp.csproj" />
   </ItemGroup>

--- a/RoboSharp.Extensions/SymbolicLinkSupport/SymbolicLink.cs
+++ b/RoboSharp.Extensions/SymbolicLinkSupport/SymbolicLink.cs
@@ -89,6 +89,7 @@ namespace RoboSharp.Extensions.SymbolicLinkSupport
 
         public static FileSystemInfo CreateAsSymbolicLink(string linkPath, string targetPath, bool isDirectory, bool makeTargetPathRelative = false)
         {
+            VersionManager.ThrowIfNotWindowsPlatform();
             if (makeTargetPathRelative)
             {
                 targetPath = GetTargetPathRelativeToLink(linkPath, targetPath, isDirectory);
@@ -139,6 +140,7 @@ namespace RoboSharp.Extensions.SymbolicLinkSupport
 
         public static string GetLinkTarget(string path)
         {
+            VersionManager.ThrowIfNotWindowsPlatform();
             SymbolicLinkReparseData? reparseData = GetReparseData(path);
             if (reparseData is null) return null;
             var reparseDataBuffer = reparseData.Value;
@@ -156,6 +158,7 @@ namespace RoboSharp.Extensions.SymbolicLinkSupport
         /// <returns></returns>
         public static string GetJunctionTarget(string path)
         {
+            VersionManager.ThrowIfNotWindowsPlatform();
             if (!Directory.Exists(path)) return null;
             SymbolicLinkReparseData? reparseData = GetReparseData(path);
             if (reparseData is null) return null;
@@ -174,6 +177,7 @@ namespace RoboSharp.Extensions.SymbolicLinkSupport
 
         public static bool IsJunctionOrSymbolic(string path)
         {
+            VersionManager.ThrowIfNotWindowsPlatform();
             SymbolicLinkReparseData? reparseData = GetReparseData(path);
             if (reparseData is null) return false;
             SymbolicLinkReparseData data = reparseData.Value;

--- a/RoboSharp.Extensions/SymbolicLinkSupport/SymbolicLink.cs
+++ b/RoboSharp.Extensions/SymbolicLinkSupport/SymbolicLink.cs
@@ -55,7 +55,7 @@ namespace RoboSharp.Extensions.SymbolicLinkSupport
         /// </remarks>
         private const int maxRelativePathLengthUnicodeChars = 260;
 
-        [DllImport("kernel32.dll", SetLastError = true)]
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         private static extern SafeFileHandle CreateFile(
             string lpFileName,
             uint dwDesiredAccess,
@@ -65,7 +65,7 @@ namespace RoboSharp.Extensions.SymbolicLinkSupport
             uint dwFlagsAndAttributes,
             IntPtr hTemplateFile);
 
-        [DllImport("kernel32.dll", SetLastError = true)]
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         static extern bool CreateSymbolicLink(string lpSymlinkFileName, string lpTargetFileName, int dwFlags);
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]

--- a/RoboSharp.Extensions/SymbolicLinkSupport/SymbolicLink.cs
+++ b/RoboSharp.Extensions/SymbolicLinkSupport/SymbolicLink.cs
@@ -87,7 +87,7 @@ namespace RoboSharp.Extensions.SymbolicLinkSupport
             string pszTo,
             FileAttributes dwAttrTo);
 
-        public static FileSystemInfo CreateAsSymbolicLink(string linkPath, string targetPath, bool isDirectory, bool makeTargetPathRelative = false)
+        public static void CreateAsSymbolicLink(string linkPath, string targetPath, bool isDirectory, bool makeTargetPathRelative = false)
         {
             VersionManager.ThrowIfNotWindowsPlatform();
             if (makeTargetPathRelative)
@@ -106,7 +106,6 @@ namespace RoboSharp.Extensions.SymbolicLinkSupport
                     throw new IOException(exception.Message, exception);
                 }
             }
-            return isDirectory ? new DirectoryInfo(targetPath) : new FileInfo(targetPath);
         }
         
         private static string GetTargetPathRelativeToLink(string linkPath, string targetPath, bool linkAndTargetAreDirectories = false)

--- a/RoboSharp.Extensions/SymbolicLinkSupport/SymbolicLinkReparseData.cs
+++ b/RoboSharp.Extensions/SymbolicLinkSupport/SymbolicLinkReparseData.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.InteropServices;
+﻿#if !NET6_0_OR_GREATER
+
+using System.Runtime.InteropServices;
 
 namespace RoboSharp.Extensions.SymbolicLinkSupport
 {
@@ -24,3 +26,5 @@ namespace RoboSharp.Extensions.SymbolicLinkSupport
         public byte[] PathBuffer;
     }
 }
+
+#endif

--- a/RoboSharp.sln
+++ b/RoboSharp.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.32002.261
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34525.116
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RoboSharp.BackupApp", "RoboSharp.BackupApp\RoboSharp.BackupApp.csproj", "{5DB0CD4C-E049-4257-ABBB-C61F11413A0E}"
 EndProject
@@ -20,6 +20,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RoboSharp.Extensions", "RoboSharp.Extensions\RoboSharp.Extensions.csproj", "{4564B19F-12BB-4231-9CD3-A1EACA82EBD7}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RoboSharp.Extensions.UnitTests", "RoboSharp.Extensions.UnitTests\RoboSharp.Extensions.UnitTests.csproj", "{EA6EA2F3-5BC6-41A1-88FF-D772DA6DFE83}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Robosharp.ConsoleApp", "Robosharp.ConsoleApp\Robosharp.ConsoleApp.csproj", "{6278295A-2839-48F2-93F7-65BFB853F9A9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -47,6 +49,10 @@ Global
 		{EA6EA2F3-5BC6-41A1-88FF-D772DA6DFE83}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EA6EA2F3-5BC6-41A1-88FF-D772DA6DFE83}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EA6EA2F3-5BC6-41A1-88FF-D772DA6DFE83}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6278295A-2839-48F2-93F7-65BFB853F9A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6278295A-2839-48F2-93F7-65BFB853F9A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6278295A-2839-48F2-93F7-65BFB853F9A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6278295A-2839-48F2-93F7-65BFB853F9A9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RoboSharp/Authentication.cs
+++ b/RoboSharp/Authentication.cs
@@ -100,7 +100,7 @@ namespace RoboSharp
             }
             else
             {
-                if (!VersionManager.IsPlatformWindows) throw new InvalidOperationException("Authentication is only available from a windows environment.");
+                VersionManager.ThrowIfNotWindowsPlatform("Authentication is only available from a windows environment.");
                 result = null;
                 void Eval() { result = auth(command); }
                 ImpersonatedRun.Execute(domain, username, password, Eval);

--- a/RoboSharp/Authentication.cs
+++ b/RoboSharp/Authentication.cs
@@ -100,6 +100,7 @@ namespace RoboSharp
             }
             else
             {
+                if (!VersionManager.IsPlatformWindows) throw new InvalidOperationException("Authentication is only available from a windows environment.");
                 result = null;
                 void Eval() { result = auth(command); }
                 ImpersonatedRun.Execute(domain, username, password, Eval);

--- a/RoboSharp/CopyOptions.cs
+++ b/RoboSharp/CopyOptions.cs
@@ -144,7 +144,7 @@ namespace RoboSharp
         
         private IEnumerable<string> fileFilter = new[] { DefaultFileFilter };
         private string copyFlags = "DAT";
-        private string directoryCopyFlags = VersionManager.Version >= 6.2 ? "DA" : "T";
+        private string directoryCopyFlags = !VersionManager.IsPlatformWindows ? "DA" : VersionManager.Version >= 6.2 ? "DA" : "T";
 
         #endregion Option Defaults
 
@@ -577,6 +577,7 @@ namespace RoboSharp
         public string Parse(bool optionsOnly = false)
         {
             Debugger.Instance.DebugMessage("Parsing CopyOptions...");
+            bool isNotWindows = !VersionManager.IsPlatformWindows;
             var version = VersionManager.Version;
             var options = new StringBuilder();
 
@@ -603,7 +604,7 @@ namespace RoboSharp
                 options.Append(string.Format(COPY_FLAGS, cleanedCopyFlags));
                 Debugger.Instance.DebugMessage(string.Format("Parsing CopyOptions progress ({0}).", options.ToString()));
             }
-            if (!cleanedDirectoryCopyFlags.IsNullOrWhiteSpace() && version >= 5.1260026)
+            if (!cleanedDirectoryCopyFlags.IsNullOrWhiteSpace() && (isNotWindows | version >= 5.1260026))
             {
                 options.Append(string.Format(DIRECTORY_COPY_FLAGS, cleanedDirectoryCopyFlags));
                 Debugger.Instance.DebugMessage(string.Format("Parsing CopyOptions progress ({0}).", options.ToString()));
@@ -623,7 +624,7 @@ namespace RoboSharp
                 options.Append(ENABLE_BACKUP_MODE);
             if (EnableRestartModeWithBackupFallback)
                 options.Append(ENABLE_RESTART_MODE_WITH_BACKUP_FALLBACK);
-            if (UseUnbufferedIo && version >= 6.2)
+            if (UseUnbufferedIo && (isNotWindows | version >= 6.2))
                 options.Append(USE_UNBUFFERED_IO);
             if (EnableEfsRawMode)
                 options.Append(ENABLE_EFSRAW_MODE);
@@ -669,9 +670,9 @@ namespace RoboSharp
                 options.Append(COPY_SYMBOLIC_LINK);
             if (MultiThreadedCopiesCount > 0)
                 options.Append(string.Format(MULTITHREADED_COPIES_COUNT, MultiThreadedCopiesCount));
-            if (DoNotCopyDirectoryInfo && version >= 6.2)
+            if (DoNotCopyDirectoryInfo && (isNotWindows | version >= 6.2))
                 options.Append(DO_NOT_COPY_DIRECTORY_INFO);
-            if (DoNotUseWindowsCopyOffload && version >= 6.2)
+            if (DoNotUseWindowsCopyOffload && (isNotWindows | version >= 6.2))
                 options.Append(DO_NOT_USE_WINDOWS_COPY_OFFLOAD);
             if (Compress)
                 options.Append(NETWORK_COMPRESSION);

--- a/RoboSharp/ExtensionMethods.cs
+++ b/RoboSharp/ExtensionMethods.cs
@@ -50,7 +50,7 @@ namespace RoboSharp
         internal static bool IsPathFullyQualified(this string path) => System.IO.Path.IsPathFullyQualified(path);
 #endif
 
-        internal static string Remove(this string text, string removal, StringComparison comparison = StringComparison.InvariantCultureIgnoreCase)
+        internal static string RemoveFirstOccurrence(this string text, string removal, StringComparison comparison = StringComparison.InvariantCultureIgnoreCase)
         {
             if (string.IsNullOrWhiteSpace(text) | string.IsNullOrWhiteSpace(removal) || !text.Contains(removal, comparison))
                 return text;

--- a/RoboSharp/NativeMethods.cs
+++ b/RoboSharp/NativeMethods.cs
@@ -6,6 +6,7 @@ namespace RoboSharp
 {
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
     
+    /// <summary>
     /// Native Methods for Pause/Suspend/Resume processes
     /// </summary>
     public static class NativeMethods

--- a/RoboSharp/NativeMethods.cs
+++ b/RoboSharp/NativeMethods.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 namespace RoboSharp
 {
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-    /// <summary>
+    
     /// Native Methods for Pause/Suspend/Resume processes
     /// </summary>
     public static class NativeMethods
@@ -34,6 +34,7 @@ namespace RoboSharp
         public static bool Suspend(this Process process)
         {
             if (process.HasExited) return false;
+            if (!VersionManager.IsPlatformWindows) throw new InvalidOperationException("This operation is only available in a windows environment.");
             foreach (ProcessThread thread in process.Threads)
             {
                 var pOpenThread = OpenThread(ThreadAccess.SUSPEND_RESUME, false, (uint)thread.Id);
@@ -48,6 +49,7 @@ namespace RoboSharp
         public static bool Resume(this Process process)
         {
             if (process.HasExited) return false;
+            if (!VersionManager.IsPlatformWindows) throw new InvalidOperationException("This operation is only available in a windows environment.");
             foreach (ProcessThread thread in process.Threads)
             {
                 var pOpenThread = OpenThread(ThreadAccess.SUSPEND_RESUME, false, (uint)thread.Id);

--- a/RoboSharp/NativeMethods.cs
+++ b/RoboSharp/NativeMethods.cs
@@ -34,7 +34,7 @@ namespace RoboSharp
         public static bool Suspend(this Process process)
         {
             if (process.HasExited) return false;
-            if (!VersionManager.IsPlatformWindows) throw new InvalidOperationException("This operation is only available in a windows environment.");
+            VersionManager.ThrowIfNotWindowsPlatform();
             foreach (ProcessThread thread in process.Threads)
             {
                 var pOpenThread = OpenThread(ThreadAccess.SUSPEND_RESUME, false, (uint)thread.Id);
@@ -49,7 +49,7 @@ namespace RoboSharp
         public static bool Resume(this Process process)
         {
             if (process.HasExited) return false;
-            if (!VersionManager.IsPlatformWindows) throw new InvalidOperationException("This operation is only available in a windows environment.");
+            VersionManager.ThrowIfNotWindowsPlatform();
             foreach (ProcessThread thread in process.Threads)
             {
                 var pOpenThread = OpenThread(ThreadAccess.SUSPEND_RESUME, false, (uint)thread.Id);

--- a/RoboSharp/RetryOptions.cs
+++ b/RoboSharp/RetryOptions.cs
@@ -50,6 +50,7 @@ namespace RoboSharp
         /// Specifies the number of retries N on failed copies (default is 0).
         /// [/R:N]
         /// </summary>
+        /// <remarks>RoboCopy default = 1 million retries (1000000)</remarks>
         [DefaultValue(0)]
         public virtual int RetryCount
         {
@@ -92,10 +93,13 @@ namespace RoboSharp
         {
             var options = new StringBuilder();
 
-            options.Append(string.Format(RETRY_COUNT, RetryCount));
-            options.Append(string.Format(RETRY_WAIT_TIME, RetryWaitTime));
+            if (RetryCount >= 0 && RetryCount != 1000000)
+                options.Append(string.Format(RETRY_COUNT, RetryCount));
+            
+            if (RetryWaitTime >= 0 && RetryWaitTime != 30)
+                options.Append(string.Format(RETRY_WAIT_TIME, RetryWaitTime));
 
-            if (SaveToRegistry)
+            if (SaveToRegistry && VersionManager.IsPlatformWindows)
                 options.Append(SAVE_TO_REGISTRY);
             if (WaitForSharenames)
                 options.Append(WAIT_FOR_SHARENAMES);

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -175,6 +175,7 @@ namespace RoboSharp
         private bool isPaused;
         private bool isRunning;
         private bool isCancelled;
+        private bool isScheduled;
         private Results.ResultsBuilder resultsBuilder;
 
         /// <summary>
@@ -200,7 +201,7 @@ namespace RoboSharp
         /// <summary> Value indicating if process was Cancelled </summary>
         public bool IsCancelled { get { return isCancelled; } }
         /// <summary> TRUE if <see cref="CopyOptions.RunHours"/> is set up (Copy Operation is scheduled to only operate within specified timeframe). Otherwise False. </summary>
-        public bool IsScheduled { get => !String.IsNullOrWhiteSpace(CopyOptions?.RunHours); }
+        public bool IsScheduled { get => isScheduled; }
         /// <summary> Get the parameters string passed to RoboCopy based on the current setup </summary>
         public string CommandOptions { get { return GenerateParameters(); } }
         /// <inheritdoc cref="RoboSharp.CopyOptions"/>
@@ -452,6 +453,7 @@ namespace RoboSharp
             isCancelled = false;
             isPaused = false;
             isRunning = true;
+            isScheduled = !String.IsNullOrWhiteSpace(CopyOptions?.RunHours) && CopyOptions.IsRunHoursStringValid(CopyOptions.RunHours);
 
             resultsBuilder = new Results.ResultsBuilder(this);
             results = null;
@@ -572,6 +574,7 @@ namespace RoboSharp
                 //Run Post-Processing of the Generated JobFile if one was created.
                 JobOptions.RunPostProcessing(this);
 
+                isScheduled = false;
                 isRunning = false; //Now that all processing is complete, IsRunning should be reported as false.
 
                 if (continuation.IsFaulted && !WasCancelled) // If some fault occurred while processing, throw the exception to caller

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -441,7 +441,7 @@ namespace RoboSharp
         /// <inheritdoc cref="Authentication.AuthenticateSourceAndDestination"/>
         public virtual Task Start(string domain = "", string username = "", string password = "")
         {
-            if (!VersionManager.IsPlatformWindows) throw new InvalidOperationException("RoboCommand (robocopy) is only available in a windows environment. Use a custom implementation instead.");
+            VersionManager.ThrowIfNotWindowsPlatform("RoboCommand (robocopy) is only available in a windows environment. Use a custom implementation instead.");
             if (disposedValue) throw GetDisposedException();
             if (process != null | IsRunning) throw new InvalidOperationException("RoboCommand.Start() method cannot be called while process is already running / IsRunning = true.");
 

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -441,7 +441,7 @@ namespace RoboSharp
         /// <inheritdoc cref="Authentication.AuthenticateSourceAndDestination"/>
         public virtual Task Start(string domain = "", string username = "", string password = "")
         {
-            VersionManager.ThrowIfNotWindowsPlatform("RoboCommand (robocopy) is only available in a windows environment. Use a custom implementation instead.");
+            VersionManager.ThrowIfNotWindowsPlatform("RoboCommand.Start(), which invokes robocopy, is only available in a windows environment. Use a custom implementation instead.");
             if (disposedValue) throw GetDisposedException();
             if (process != null | IsRunning) throw new InvalidOperationException("RoboCommand.Start() method cannot be called while process is already running / IsRunning = true.");
 

--- a/RoboSharp/RoboCommand.cs
+++ b/RoboSharp/RoboCommand.cs
@@ -441,6 +441,7 @@ namespace RoboSharp
         /// <inheritdoc cref="Authentication.AuthenticateSourceAndDestination"/>
         public virtual Task Start(string domain = "", string username = "", string password = "")
         {
+            if (!VersionManager.IsPlatformWindows) throw new InvalidOperationException("RoboCommand (robocopy) is only available in a windows environment. Use a custom implementation instead.");
             if (disposedValue) throw GetDisposedException();
             if (process != null | IsRunning) throw new InvalidOperationException("RoboCommand.Start() method cannot be called while process is already running / IsRunning = true.");
 

--- a/RoboSharp/RoboCommandParser.cs
+++ b/RoboSharp/RoboCommandParser.cs
@@ -137,7 +137,7 @@ namespace RoboSharp
                 .ParseCopyOptions(sanitizedCmd, out sanitizedCmd)
                 .ParseLoggingOptions(sanitizedCmd, out sanitizedCmd)
                 .ParseSelectionOptions(sanitizedCmd, out sanitizedCmd)
-                .ParseRetryOptions(sanitizedCmd, out sanitizedCmd);
+                .ParseRetryOptions(sanitizedCmd, out _);
         }
 
         #region < Copy Options Parsing >
@@ -332,7 +332,7 @@ namespace RoboSharp
             
             return roboCommand;
 
-            string ExtractLogPath(string filter, string input, out string output)
+            static string ExtractLogPath(string filter, string input, out string output)
             {
                 if (TryExtractParameter(input, filter, out string path, out output))
                 {

--- a/RoboSharp/RoboCommandParserFunctions.cs
+++ b/RoboSharp/RoboCommandParserFunctions.cs
@@ -22,9 +22,6 @@ namespace RoboSharp
         /// </summary>
         public readonly struct ParsedSourceDest
         {
-            #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-            
-
             public ParsedSourceDest(string input) : this(string.Empty, string.Empty, input, input) { }
 
             public ParsedSourceDest(string source, string dest, string input, string sanitized)
@@ -39,8 +36,6 @@ namespace RoboSharp
             public readonly string InputString;
             /// <summary> The InputString with the Source and Destination removed </summary>
             public readonly string SanitizedString;
-
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
         }
 
         /// <summary>

--- a/RoboSharp/RoboCommandParserFunctions.cs
+++ b/RoboSharp/RoboCommandParserFunctions.cs
@@ -116,7 +116,8 @@ namespace RoboSharp
             else if (sourceEmpty && destEmpty)
             {
                 Debugger.Instance.DebugMessage($"--> Source and Destination Pattern Match Success: Neither specified");
-                return new ParsedSourceDest(string.Empty, string.Empty, inputText, inputText);
+                string sanitized = !match.Success ? inputText : inputText.RemoveFirstOccurrence(rawSource).RemoveFirstOccurrence(rawDest);
+                return new ParsedSourceDest(string.Empty, string.Empty, inputText, sanitized);
             }
             else
             {

--- a/RoboSharp/RoboCommandParserFunctions.cs
+++ b/RoboSharp/RoboCommandParserFunctions.cs
@@ -52,7 +52,7 @@ namespace RoboSharp
             //lang=regex 
             const string rc = @"^(?<rc>\s*((?<sQuote>"".+?[:$].+?robocopy(\.exe)?"")|(?<sNoQuote>([^:*?""<>|\s]+?[:$][^:*?<>|\s]+?)?robocopy(\.exe)?))\s+)";
             var match = Regex.Match(input, rc, RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture| RegexOptions.CultureInvariant);
-            string ret = match.Success ? input.Remove(match.Groups[0].Value) : input;
+            string ret = match.Success ? input.RemoveFirstOccurrence(match.Groups[0].Value) : input;
             return ret;
         }
 
@@ -111,7 +111,7 @@ namespace RoboSharp
                 Debugger.Instance.DebugMessage($"--> Source and Destination Pattern Match Success:");
                 Debugger.Instance.DebugMessage($"----> Source : " + source);
                 Debugger.Instance.DebugMessage($"----> Destination : " + dest);
-                return new ParsedSourceDest(source, dest, inputText, inputText.Remove(rawSource).Remove(rawDest));
+                return new ParsedSourceDest(source, dest, inputText, inputText.RemoveFirstOccurrence(rawSource).RemoveFirstOccurrence(rawDest));
             }
             else if (sourceEmpty && destEmpty)
             {
@@ -168,9 +168,9 @@ namespace RoboSharp
                 subSection = subSection.Substring(0, substringLength); // Reduce the subsection down to the relevant portion by cutting off at the next parameter switch
             }
 
-            value = subSection.Remove(prefix).Trim();
+            value = subSection.RemoveFirstOccurrence(prefix).Trim();
             Debugger.Instance.DebugMessage($"--> Switch {prefix} found. Value : {value}");
-            modifiedText = inputText.Remove(subSection);
+            modifiedText = inputText.RemoveFirstOccurrence(subSection);
             return true;
         }
 
@@ -186,7 +186,7 @@ namespace RoboSharp
         {
             bool value = inputText.Contains(flag, StringComparison.InvariantCultureIgnoreCase);
             Debugger.Instance.DebugMessage($"--> Switch {flag}{(value ? "" : " not")} detected.");
-            modifiedText = !value ? inputText : inputText.Remove(flag);
+            modifiedText = !value ? inputText : inputText.RemoveFirstOccurrence(flag);
             if (value) actionIfTrue?.Invoke();
             return value;
         }
@@ -258,7 +258,7 @@ namespace RoboSharp
 
             var match = Regex.Match(input, FileFilter, RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
             string foundFilters = match.Groups["filter"].Value;
-            modifiedText = input.Remove(foundFilters);
+            modifiedText = input.RemoveFirstOccurrence(foundFilters);
 
             if (match.Success && !string.IsNullOrWhiteSpace(foundFilters))
             {
@@ -286,7 +286,7 @@ namespace RoboSharp
             foreach (Match c in matchCollection)
             {
                 string s = c.Groups["filter"].Value;
-                modifiedText = modifiedText.Remove(s);
+                modifiedText = modifiedText.RemoveFirstOccurrence(s);
                 s = s.TrimStart("/XF").Trim();
                 if (!string.IsNullOrWhiteSpace(s))
                 {
@@ -307,7 +307,7 @@ namespace RoboSharp
             foreach (Match c in matchCollection)
             {
                 string s = c.Groups["filter"].Value;
-                modifiedText = modifiedText.Remove(s);
+                modifiedText = modifiedText.RemoveFirstOccurrence(s);
                 s = s.TrimStart("/XD").Trim();
                 if (!string.IsNullOrWhiteSpace(s))
                 {

--- a/RoboSharp/RoboSharp.csproj
+++ b/RoboSharp/RoboSharp.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net452;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>1.4.0</Version>
-    <Copyright>Copyright 2023</Copyright>
+    <Copyright>Copyright 2024</Copyright>
     <Authors>Terry</Authors>
     <owners>Terry</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/RoboSharp/RoboSharp.csproj
+++ b/RoboSharp/RoboSharp.csproj
@@ -7,7 +7,6 @@
     <Copyright>Copyright 2023</Copyright>
     <Authors>Terry</Authors>
     <owners>Terry</owners>
-	  <langversion>8.0</langversion>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <PackageLicenseUrl>https://github.com/tjscience/RoboSharp/blob/master/license</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/tjscience/RoboSharp</PackageProjectUrl>
@@ -17,6 +16,10 @@
     <PackageReleaseNotes>Introduce RoboCommandParser - Provides the ability to submit a robocopy command string into the library and return the equivalent IRoboCommand object.</PackageReleaseNotes>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'netstandard2.0'">
+    <langversion>8.0</langversion>
+  </PropertyGroup>
+    
   <ItemGroup Condition="'$(TargetFramework)' == 'net40' Or '$(TargetFramework)' == 'net452'">
     <Reference Include="System.Management" />
   </ItemGroup>
@@ -31,9 +34,5 @@
     <Compile Remove="XML_Files\**" />
     <EmbeddedResource Remove="XML_Files\**" />
     <None Remove="XML_Files\**" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Properties\" />
   </ItemGroup>
 </Project>

--- a/RoboSharp/RoboSharp.csproj
+++ b/RoboSharp/RoboSharp.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.3.6</Version>
+    <Version>1.4.0</Version>
     <Copyright>Copyright 2023</Copyright>
     <Authors>Terry</Authors>
     <owners>Terry</owners>

--- a/RoboSharp/VersionManager.cs
+++ b/RoboSharp/VersionManager.cs
@@ -82,6 +82,12 @@ namespace RoboSharp
             System.Threading.Thread.CurrentThread.CurrentCulture = customCulture;
         }
 
+        /// <exception cref="PlatformNotSupportedException"></exception>
+        public static void ThrowIfNotWindowsPlatform(string message = default)
+        {
+            if (!IsPlatformWindows)
+                throw new PlatformNotSupportedException(message ?? "This function is only available on Windows");
+        }
 
         private static string GetOsVersion()
         {

--- a/RoboSharpUnitTesting/RoboCommandParserFunctionsTests.cs
+++ b/RoboSharpUnitTesting/RoboCommandParserFunctionsTests.cs
@@ -26,7 +26,6 @@ namespace RoboSharp.UnitTests
             const string fullPathExe = @"c:\windows\system32\robocopy.exe ";
             const string quotedPath = @"""c:\windows\system32\robocopy"" ";
             const string quotedPathExe = @"""D:\Some Other\Folder\robocopy.exe"" ";
-            int i = 0;
 
             // trim entire string
             Assert.AreEqual(string.Empty, Trim(nonQuoted), "\nFailed Trim All - Test 1");
@@ -42,7 +41,7 @@ namespace RoboSharp.UnitTests
                 "*.txt /xf",
                 @"""C:\source\robocopy\"" ""D:\Dest\"" /a /b /c"
             };
-            i = 0;
+            int i = 0;
 
             foreach (string testStr in testArray) 
             {   

--- a/RoboSharpUnitTesting/RoboCommandParserTests.cs
+++ b/RoboSharpUnitTesting/RoboCommandParserTests.cs
@@ -259,7 +259,7 @@ namespace RoboSharp.UnitTests
             // Note : Due to how RoboCommand prints out file filters, ensure input file filters are always quoted
             IRoboCommand cmdResult = RoboCommandParser.Parse(input);
             cmdResult.LoggingOptions.PrintSizesAsBytes = false;
-            string expected = input += " /R:0"; // robocommand ALWAYS prints these values
+            string expected = input + " /R:0"; // robocommand ALWAYS prints these values
 
             Assert.AreEqual(expected.Trim(), cmdResult.ToString().Trim(), $"\n\nProduced Command is not equal!\nExpected:\t{expected}\n  Result:\t{cmdResult}"); // Final test : both should produce the same ToString()
             Console.WriteLine($"\n\n Input : {input}");

--- a/RoboSharpUnitTesting/RoboCommandParserTests.cs
+++ b/RoboSharpUnitTesting/RoboCommandParserTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RoboSharp;
 using RoboSharp.Interfaces;
 using System;
@@ -259,7 +259,7 @@ namespace RoboSharp.UnitTests
             // Note : Due to how RoboCommand prints out file filters, ensure input file filters are always quoted
             IRoboCommand cmdResult = RoboCommandParser.Parse(input);
             cmdResult.LoggingOptions.PrintSizesAsBytes = false;
-            string expected = input += " /R:0 /W:30"; // robocommand ALWAYS prints these values
+            string expected = input += " /R:0"; // robocommand ALWAYS prints these values
 
             Assert.AreEqual(expected.Trim(), cmdResult.ToString().Trim(), $"\n\nProduced Command is not equal!\nExpected:\t{expected}\n  Result:\t{cmdResult}"); // Final test : both should produce the same ToString()
             Console.WriteLine($"\n\n Input : {input}");

--- a/RoboSharpUnitTesting/RoboCommandParserTests.cs
+++ b/RoboSharpUnitTesting/RoboCommandParserTests.cs
@@ -17,7 +17,7 @@ namespace RoboSharp.UnitTests
             Console.WriteLine("--- " + args.Message);
         }
 
-        const string CmdEndText = @" /R:0 /W:30 /BYTES";
+        const string CmdEndText = @" /R:0 /BYTES";
 
         private static RoboCommand GetNewCommand(string source = default, string destination =  default) => new RoboCommand(
             source: source.IsNullOrWhiteSpace() ?  "C:\\Source" : source,
@@ -29,20 +29,33 @@ namespace RoboSharp.UnitTests
         /// <summary>
         /// Use this one when debugging specific commands that are not deciphering for you!
         /// </summary>
+        
         [DataRow("\"\" \"\" \"*.txt\" \"*.pdf\"", DisplayName = "No Source or Dest")]
         [DataRow("robocopy.exe \"C:\\MySource\" \"D:\\My Destination\" \"*.txt\" \"*.pdf\"", DisplayName = "quoted filters")]
         [DataRow("\"D:\\Some Folder\\robocopy.exe\" \"C:\\MySource\" \"D:\\My Destination\" *.txt *.pdf", DisplayName = "multiple unquoted filters")]
         [DataRow("c:\\windows\\system32\\robocopy.exe \"C:\\MySource\" \"D:\\My Destination\" *.txt", DisplayName = ".txt Only")]
         [DataRow("robocopy \"C:\\MySource\" \"D:\\My Destination\" /MOVE", DisplayName = "Example")]
         [TestMethod()]
-        public void TestCustomParameters(string command)
+        public void PrintOnly(string command)
         {
             Debugger.Instance.DebugMessageEvent += DebuggerWriteLine;
             IRoboCommand cmd = RoboCommandParser.Parse(command);
             Debugger.Instance.DebugMessageEvent -= DebuggerWriteLine;
             Console.WriteLine($"\n\n Input : {command}");
             Console.WriteLine($"Output : {cmd}");
-            //Assert.AreEqual(command, command.ToString(), true);
+        }
+
+        [DataRow(@"robocopy """" """" *.docx /E", @" ""*.docx"" /E" + CmdEndText, DisplayName = "No Source or Dest - 1")]
+        [TestMethod()]
+        public void TestCustomParameters(string command, string expected)
+        {
+            Debugger.Instance.DebugMessageEvent += DebuggerWriteLine;
+            IRoboCommand cmd = RoboCommandParser.Parse(command);
+            Debugger.Instance.DebugMessageEvent -= DebuggerWriteLine;
+            Console.WriteLine($"\n\n   Input : {command}");
+            Console.WriteLine($"  Output : {cmd.ToString().Trim()}");
+            Console.WriteLine($"Expected : {expected.Trim()}");
+            Assert.AreEqual(expected.Trim(), cmd.ToString().Trim(), true);
         }
 
         [DataRow("C:\\source", "D:\\destination", DisplayName = "No Quotes")]

--- a/Robosharp.ConsoleApp/Program.cs
+++ b/Robosharp.ConsoleApp/Program.cs
@@ -1,0 +1,66 @@
+﻿using RoboSharp;
+using RoboSharp.Interfaces;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+// This example console app uses Top-Level Statements introduced in .Net6, hence no need for a 'Program' class with a 'Main' routine.
+// See https://aka.ms/new-console-template for more information
+
+try
+{
+    // Change this to the desired factory - a custom factory will be required for use with linux systems
+    IRoboCommandFactory commandFactory = RoboCommandFactory.Default;
+
+    // Get the command and execute it
+    IRoboCommand cmd;
+    if (args != null && args.Where(s => !string.IsNullOrWhiteSpace(s)).Any())
+    {
+        cmd = RoboSharp.RoboCommandParser.Parse(new StringBuilder().AppendJoin(' ', args).ToString(), commandFactory);
+    }
+    else
+    {
+        cmd = AskForCommandParameters(commandFactory);
+    }
+    cmd.OnFileProcessed += Cmd_OnFileProcessed;
+    cmd.OnError += Cmd_OnError;
+    await cmd.Start(); // If using the default factory, this will throw PlatformNotSupported in a non-windows environment!
+}
+catch(Exception e)
+{
+    Console.WriteLine(e.Message);
+    Console.ReadLine();
+    System.Environment.Exit(1);
+}
+System.Environment.Exit(0);
+
+
+static IRoboCommand AskForCommandParameters(IRoboCommandFactory factory)
+{
+    while (true)
+    {
+        try
+        {
+            Console.WriteLine("Enter your Robocopy command to be parsed: ");
+            string input = Console.ReadLine();
+            IRoboCommand command = RoboSharp.RoboCommandParser.Parse(input, factory);
+            return command;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex.Message);
+            Console.WriteLine("\n\n-------------------------------------------");
+        }
+    }
+}
+
+static void Cmd_OnFileProcessed(IRoboCommand sender, FileProcessedEventArgs e)
+{
+    Console.WriteLine(e.ProcessedFile.ToString());
+}
+
+static void Cmd_OnError(IRoboCommand sender, RoboSharp.ErrorEventArgs e)
+{
+    Console.WriteLine(e.Error);
+}

--- a/Robosharp.ConsoleApp/Program.cs
+++ b/Robosharp.ConsoleApp/Program.cs
@@ -29,8 +29,8 @@ try
     Console.WriteLine("Command Parsed Successfully -- Starting command.\n");
     cmd.OnFileProcessed += Cmd_OnFileProcessed;
     cmd.OnError += Cmd_OnError;
-    using (cmd);
     await cmd.Start(); // If using the default factory, this will throw PlatformNotSupported in a non-windows environment!
+    if (cmd is IDisposable dp) dp.Dispose();
 }
 catch(Exception e)
 {

--- a/Robosharp.ConsoleApp/Program.cs
+++ b/Robosharp.ConsoleApp/Program.cs
@@ -10,6 +10,9 @@ using System.Threading.Tasks;
 
 try
 {
+    // test construction of a basic command
+    using (var testCmd = new RoboCommand()){ }
+
     // Change this to the desired factory - a custom factory will be required for use with linux systems
     IRoboCommandFactory commandFactory = RoboCommandFactory.Default;
 
@@ -26,6 +29,7 @@ try
     Console.WriteLine("Command Parsed Successfully -- Starting command.\n");
     cmd.OnFileProcessed += Cmd_OnFileProcessed;
     cmd.OnError += Cmd_OnError;
+    using (cmd);
     await cmd.Start(); // If using the default factory, this will throw PlatformNotSupported in a non-windows environment!
 }
 catch(Exception e)

--- a/Robosharp.ConsoleApp/Program.cs
+++ b/Robosharp.ConsoleApp/Program.cs
@@ -1,4 +1,4 @@
-﻿using RoboSharp;
+using RoboSharp;
 using RoboSharp.Interfaces;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
@@ -23,6 +23,7 @@ try
     {
         cmd = AskForCommandParameters(commandFactory);
     }
+    Console.WriteLine("Command Parsed Successfully -- Starting command.\n");
     cmd.OnFileProcessed += Cmd_OnFileProcessed;
     cmd.OnError += Cmd_OnError;
     await cmd.Start(); // If using the default factory, this will throw PlatformNotSupported in a non-windows environment!

--- a/Robosharp.ConsoleApp/Robosharp.ConsoleApp.csproj
+++ b/Robosharp.ConsoleApp/Robosharp.ConsoleApp.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RoboSharp.Extensions\RoboSharp.Extensions.csproj" />
+    <ProjectReference Include="..\RoboSharp\RoboSharp.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
- Modifies IsScheduled evaluation to avoid evaluation the CopyOptions object, which may have already been collected
- Added a IsWindowsPlatform field to VersionManager. Wrote in various checks for this to throw PlatformNotSupported exceptions for non-windows platforms as needed.
- Rewrote some logic to use newer .Net6 functionality instead of using DLL Imports that are windows only. 
- Fix RoboCommandParser failing to parse when submitted with quoted empty paths for source/destination