### PR TITLE
Resolves EU number formatting -- Adds .Net8.0 target

### DIFF
--- a/RoboSharp/Results/SpeedStatistic.cs
+++ b/RoboSharp/Results/SpeedStatistic.cs
@@ -306,7 +306,7 @@ namespace RoboSharp.Results
 #endif
         internal void Add(IEnumerable<ISpeedStatistic> stats, bool ForceTreatAsSpeedStat = false)
         {
-            foreach (SpeedStatistic stat in stats)
+            foreach (ISpeedStatistic stat in stats)
                 Add(stat, ForceTreatAsSpeedStat);
         }
 

--- a/RoboSharp/Results/SpeedStatistic.cs
+++ b/RoboSharp/Results/SpeedStatistic.cs
@@ -127,22 +127,29 @@ namespace RoboSharp.Results
         {
             var res = new SpeedStatistic();
 
-            var pattern = new Regex(@"\d+([.,]\d+)+");
-            Match match;
-
-            match = pattern.Match(line1);
+            Regex pattern = new Regex(@"\d+([.,]\d+)+", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+            Match match = pattern.Match(line1);
             if (match.Success)
             {
-                res.BytesPerSec = decimal.Parse(match.Value);
+                res.BytesPerSec = decimal.Parse(match.Value.Replace(".",""));
             }
 
             match = pattern.Match(line2);
             if (match.Success)
             {
-                res.MegaBytesPerMin = decimal.Parse(match.Value);
+                res.MegaBytesPerMin = decimal.Parse(sanitizeMB(match.Value));
             }
 
             return res;
+
+            static string sanitizeMB(string text)
+            {
+                int decPoint = text.LastIndexOfAny(new char[] { ',', '.' });
+                if (decPoint == -1) return text;
+                string tValue = text.Substring(0, decPoint).Replace(".", ""); // sanitize thousands
+                string dValue = text.Substring(decPoint).Replace(",", "."); // sanitize decimal
+                return tValue + dValue;
+            }
         }
 
         #endregion

--- a/RoboSharp/Results/Statistic.cs
+++ b/RoboSharp/Results/Statistic.cs
@@ -639,7 +639,7 @@ namespace RoboSharp.Results
         /// <param name="stats">Statistics Item to add</param>
         public void AddStatistic(IEnumerable<IStatistic> stats)
         {
-            foreach (Statistic stat in stats)
+            foreach (IStatistic stat in stats)
             {
                 EnablePropertyChangeEvent = stat == stats.Last();
                 AddStatistic(stat);
@@ -784,7 +784,7 @@ namespace RoboSharp.Results
         /// <param name="stats">Statistics Item to subtract</param>
         public void Subtract(IEnumerable<IStatistic> stats)
         {
-            foreach (Statistic stat in stats)
+            foreach (IStatistic stat in stats)
             {
                 EnablePropertyChangeEvent = stat == stats.Last();
                 Subtract(stat);

--- a/RoboSharp/RoboSharp.csproj
+++ b/RoboSharp/RoboSharp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.4.1</Version>
+    <Version>1.4.2</Version>
     <Copyright>Copyright 2024</Copyright>
     <Authors>Terry</Authors>
     <owners>Terry</owners>
@@ -13,7 +13,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/tjscience/RoboSharp/master/robosharp.png</PackageIconUrl>
     <Description>RoboSharp is a .NET wrapper for the awesome Robocopy windows application.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>Introduce RoboCommandParser - Provides the ability to submit a robocopy command string into the library and return the equivalent IRoboCommand object.</PackageReleaseNotes>
+    <PackageReleaseNotes>Various fixes</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'netstandard2.0'">

--- a/RoboSharp/RoboSharp.csproj
+++ b/RoboSharp/RoboSharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0;net8.0;</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>1.4.2</Version>
     <Copyright>Copyright 2024</Copyright>

--- a/RoboSharp/VersionManager.cs
+++ b/RoboSharp/VersionManager.cs
@@ -95,7 +95,9 @@ namespace RoboSharp
         {
             if (!IsPlatformWindows) return Environment.OSVersion.Version.ToString();
 
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
+#if NET8_0_OR_GREATER 
+
+#elif NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
             using (var session = Microsoft.Management.Infrastructure.CimSession.Create("."))
 
             {

--- a/RoboSharpUnitTesting/RoboCommandEventTests.cs
+++ b/RoboSharpUnitTesting/RoboCommandEventTests.cs
@@ -9,9 +9,9 @@ namespace RoboSharp.UnitTests
     [TestClass]
     public class RoboCommandEventTests
     {
-        private void RunTestThenAssert(IRoboCommand cmd, ref bool EventBool)
+        private static void RunTestThenAssert(IRoboCommand cmd, ref bool EventBool)
         {
-            var results = cmd.StartAsync().Result;
+            var results = cmd.StartAsync().GetAwaiter().GetResult();
             Test_Setup.WriteLogLines(results);
             if (!EventBool) throw new AssertFailedException("Subscribed Event was not Raised!");
         }

--- a/RoboSharpUnitTesting/RoboSharpUnitTesting.csproj
+++ b/RoboSharpUnitTesting/RoboSharpUnitTesting.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net472;netcoreapp3.1;net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <RootNamespace>RoboSharp.UnitTests</RootNamespace>
         <AssemblyName>RoboSharp.UnitTests</AssemblyName>

--- a/RoboSharpUnitTesting/SpeedStatisticTests.cs
+++ b/RoboSharpUnitTesting/SpeedStatisticTests.cs
@@ -12,24 +12,27 @@ namespace RoboSharp.UnitTests
     public class SpeedStatisticTests
     {
         [TestMethod]
-        public void ParseTest()
+        public void ParseTest_CommaThousands() => ParseInputTest("538,252,733", 538252733m, "30,799.068", 30799.068m);
+
+        [TestMethod]
+        public void ParseTest_PeriodThousands() => ParseInputTest("538.252.733", 538252733m, "30.799,068", 30799.068m);
+
+        private void ParseInputTest(string sBPS, decimal bps, string sMB, decimal MB)
         {
-            string bps_string = " 538,252,733";
-            decimal bps = 538252733;
-
-            string mbpm_string = "30,799.068";
-            decimal mbpm = 30799.068m;
-
-            Console.Write("Validating Decimal.Parse()");
-            Assert.AreEqual(bps, decimal.Parse(bps_string), "\ndecimal parsing fails - bps");
-            Assert.AreEqual(mbpm, decimal.Parse(mbpm_string), "\ndecimal parsing fails - mbpm");
-            Console.WriteLine(" -- OK");
-
             Console.Write("Validating SpeedStatistic.Parse()");
-            var stat = SpeedStatistic.Parse(bps_string, mbpm_string);
+            var stat = SpeedStatistic.Parse(sBPS, sMB);
             Assert.AreEqual(bps, stat.BytesPerSec, "\nBytes/second does not match!");
-            Assert.AreEqual(mbpm, stat.MegaBytesPerMin, "\nMegabytes/min does not match!");
+            Assert.AreEqual(MB, stat.MegaBytesPerMin, "\nMegabytes/min does not match!");
             Console.WriteLine(" -- OK");
+        }
+
+        [DataRow(" Velocità:           257.555.063 Byte/sec.", " Velocità:             14737,419 MB/min.")]
+        [TestMethod]
+        public void ParseText(string sBPS, string sMB) 
+        {
+            var value = SpeedStatistic.Parse(sBPS, sMB);
+            Assert.IsNotNull(value);
+            Console.WriteLine(value.ToString());
         }
     }
 }

--- a/Robosharp.ConsoleApp/Program.cs
+++ b/Robosharp.ConsoleApp/Program.cs
@@ -48,7 +48,7 @@ static IRoboCommand AskForCommandParameters(IRoboCommandFactory factory)
         try
         {
             Console.WriteLine("Enter your Robocopy command to be parsed: ");
-            string input = Console.ReadLine();
+            string? input = Console.ReadLine();
             IRoboCommand command = RoboSharp.RoboCommandParser.Parse(input, factory);
             return command;
         }


### PR DESCRIPTION
Resolves number formatting issues where `,` is used for decimal places.

statisticLines[4] = " Velocità:           257.555.063 Byte/sec."
statisticLines[5] = " Velocità:             14737,419 MB/min."
