### PR TITLE
203 Supplement - Rework Process.Exited handler

### DIFF
--- a/RoboSharp.BackupApp/app.manifest
+++ b/RoboSharp.BackupApp/app.manifest
@@ -15,8 +15,9 @@
             Specifying requestedExecutionLevel node will disable file and registry virtualization.
             If you want to utilize File and Registry Virtualization for backward 
             compatibility then delete the requestedExecutionLevel node.
+        
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
         -->
-        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
       </requestedPrivileges>
     </security>
   </trustInfo>

--- a/RoboSharp/RoboSharp.csproj
+++ b/RoboSharp/RoboSharp.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>net452;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0;net8.0;</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>1.5.01</Version>
     <Copyright>Copyright 2024</Copyright>

--- a/RoboSharp/RoboSharp.csproj
+++ b/RoboSharp/RoboSharp.csproj
@@ -1,9 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0;net8.0;</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.5.0</Version>
+    <Version>1.5.01</Version>
     <Copyright>Copyright 2024</Copyright>
     <Authors>Terry</Authors>
     <owners>Terry</owners>
@@ -13,10 +12,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/tjscience/RoboSharp/master/robosharp.png</PackageIconUrl>
     <Description>RoboSharp is a .NET wrapper for the awesome Robocopy windows application.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>Adds RoboSharpConfiguration.EnableFileLogging setting. 
-    This now omits the file and directory items from the RoboCopyResults.LogLines by default to reduce impact on memory during large transfers.
-    (Header and Summary will still be recorded into the results object)
-    If the original functionality is desired, set this value to TRUE and the file information will be recorded into the RoboCopyResults.LogLines
+    <PackageReleaseNotes>Minor bugfix for RoboCommand.Start()
     </PackageReleaseNotes>
   </PropertyGroup>
 


### PR DESCRIPTION
This is a supplement to #203  

- Reworks the TryCatch statement provided in 203 by wrapping it into a method call
- This now properly unsubscribes from the process object (resolving another potential memory leak)
- isolates the method variable from the class variable by renaming the class variable, ensuring that the process object is held in reference until such time that the task completes, preventing null reference exceptions due to early disposal of the robocommand while the task is still running.