### PR TITLE
Add /FFT parameter support for FAT file times

### DIFF
--- a/RoboSharp/CopyOptions.cs
+++ b/RoboSharp/CopyOptions.cs
@@ -72,6 +72,7 @@ namespace RoboSharp
             EnableRestartMode = copyOptions.EnableRestartMode;
             EnableRestartModeWithBackupFallback = copyOptions.EnableRestartModeWithBackupFallback;
             FatFiles = copyOptions.FatFiles;
+            FatFileTimes = copyOptions.FatFileTimes;
             FileFilter = copyOptions.FileFilter;
             FixFileSecurityOnAllFiles = copyOptions.FixFileSecurityOnAllFiles;
             FixFileTimesOnAllFiles = copyOptions.FixFileTimesOnAllFiles;
@@ -120,6 +121,7 @@ namespace RoboSharp
         internal const string REMOVE_ATTRIBUTES = "/A-:{0} ";
         internal const string CREATE_DIRECTORY_AND_FILE_TREE = "/CREATE ";
         internal const string FAT_FILES = "/FAT ";
+        internal const string FAT_FILE_TIMES = "/FFT ";
         internal const string TURN_LONG_PATH_SUPPORT_OFF = "/256 ";
         internal const string MONITOR_SOURCE_CHANGES_LIMIT = "/MON:{0} ";
         internal const string MONITOR_SOURCE_TIME_LIMIT = "/MOT:{0} ";
@@ -434,6 +436,13 @@ namespace RoboSharp
         public virtual bool FatFiles { get; set; }
 
         /// <summary>
+        /// Assumes FAT file times (two-second precision).
+        /// [/FFT]
+        /// </summary>
+        [DefaultValue(false)]
+        public virtual bool FatFileTimes { get; set; }
+
+        /// <summary>
         /// Turns off support for very long paths (longer than 256 characters).
         /// [/256]
         /// </summary>
@@ -654,6 +663,8 @@ namespace RoboSharp
                 options.Append(CREATE_DIRECTORY_AND_FILE_TREE);
             if (FatFiles)
                 options.Append(FAT_FILES);
+            if (FatFileTimes)
+                options.Append(FAT_FILE_TIMES);
             if (TurnLongPathSupportOff)
                 options.Append(TURN_LONG_PATH_SUPPORT_OFF);
             if (MonitorSourceChangesLimit > 0)
@@ -889,6 +900,7 @@ namespace RoboSharp
             EnableRestartMode |= copyOptions.EnableRestartMode;
             EnableRestartModeWithBackupFallback |= copyOptions.EnableRestartModeWithBackupFallback;
             FatFiles |= copyOptions.FatFiles;
+            FatFileTimes |= copyOptions.FatFileTimes;
             FixFileSecurityOnAllFiles |= copyOptions.FixFileSecurityOnAllFiles;
             FixFileTimesOnAllFiles |= copyOptions.FixFileTimesOnAllFiles;
             Mirror |= copyOptions.Mirror;

--- a/RoboSharp/JobFileBuilder.cs
+++ b/RoboSharp/JobFileBuilder.cs
@@ -306,6 +306,7 @@ namespace RoboSharp
                 EnableRestartMode = Flags.Any(flag => flag.Success && flag.Value == CopyOptions.ENABLE_RESTART_MODE.Trim()),
                 EnableRestartModeWithBackupFallback = Flags.Any(flag => flag.Success && flag.Value == CopyOptions.ENABLE_RESTART_MODE_WITH_BACKUP_FALLBACK.Trim()),
                 FatFiles = Flags.Any(flag => flag.Success && flag.Value == CopyOptions.FAT_FILES.Trim()),
+                FatFileTimes = Flags.Any(flag => flag.Success && flag.Value == CopyOptions.FAT_FILE_TIMES.Trim()),
                 FixFileSecurityOnAllFiles = Flags.Any(flag => flag.Success && flag.Value == CopyOptions.FIX_FILE_SECURITY_ON_ALL_FILES.Trim()),
                 FixFileTimesOnAllFiles = Flags.Any(flag => flag.Success && flag.Value == CopyOptions.FIX_FILE_TIMES_ON_ALL_FILES.Trim()),
                 Mirror = Flags.Any(flag => flag.Success && flag.Value == CopyOptions.MIRROR.Trim()),

--- a/RoboSharp/RoboCommandParser.cs
+++ b/RoboSharp/RoboCommandParser.cs
@@ -177,6 +177,7 @@ namespace RoboSharp
             options.EnableRestartMode |= ExtractFlag(sanitizedCmd, CopyOptions.ENABLE_RESTART_MODE, out sanitizedCmd);
             options.EnableRestartModeWithBackupFallback |= ExtractFlag(sanitizedCmd, CopyOptions.ENABLE_RESTART_MODE_WITH_BACKUP_FALLBACK, out sanitizedCmd);
             options.FatFiles |= ExtractFlag(sanitizedCmd, CopyOptions.FAT_FILES, out sanitizedCmd);
+            options.FatFileTimes |= ExtractFlag(sanitizedCmd, CopyOptions.FAT_FILE_TIMES, out sanitizedCmd);
             options.FixFileSecurityOnAllFiles |= ExtractFlag(sanitizedCmd, CopyOptions.FIX_FILE_SECURITY_ON_ALL_FILES, out sanitizedCmd);
             options.FixFileTimesOnAllFiles |= ExtractFlag(sanitizedCmd, CopyOptions.FIX_FILE_TIMES_ON_ALL_FILES, out sanitizedCmd);
             options.RemoveFileInformation |= ExtractFlag(sanitizedCmd, CopyOptions.REMOVE_FILE_INFORMATION, out sanitizedCmd);


### PR DESCRIPTION
This commit introduces support for the /FFT parameter, which assumes FAT file times with two-second precision. This enhancement is crucial for ensuring compatibility and precision in file synchronization tasks, especially when working with file systems that follow the FAT time conventions.

This update addresses the need for finer control over file time precision, making RoboSharp more versatile for users dealing with a variety of file systems.